### PR TITLE
fix for --chart not working #5

### DIFF
--- a/jesse/services/charts.py
+++ b/jesse/services/charts.py
@@ -107,7 +107,7 @@ def portfolio_vs_asset_returns():
         mode = 'PT'
     file_path = 'storage/charts/{}-{}.png'.format(
         mode, str(arrow.utcnow())[0:19]
-    )
+    ).replace(":", "-")
     plt.savefig(file_path)
     print(
         'Chart output saved at:\n{}'.format(file_path)


### PR DESCRIPTION
Fixes the Uncaught Exception: OSError: [Errno 22] Invalid argument: 'storage/charts/BT-2020-04-18T16:56:53.png'`
Windows doesn't like ":" in filenames.