### PR TITLE
Replace 'Maximum' with 'minimum' in candle import prompt

### DIFF
--- a/jesse/modes/import_candles_mode/__init__.py
+++ b/jesse/modes/import_candles_mode/__init__.py
@@ -44,7 +44,7 @@ def run(exchange: str, symbol: str, start_date_str: str, skip_confirmation=False
     # ask for confirmation
     if not skip_confirmation:
         click.confirm(
-            'Importing {} days candles from "{}" for "{}". Maximum time it\'ll take '
+            'Importing {} days candles from "{}" for "{}". Minimum time it\'ll take '
             'to finish:"{} minutes" (duplicates will be skipped). All good?'
                 .format(days_count, exchange, symbol, round(time_to_finish, 2)), abort=True, default=True)
 

--- a/jesse/modes/import_candles_mode/__init__.py
+++ b/jesse/modes/import_candles_mode/__init__.py
@@ -40,13 +40,11 @@ def run(exchange: str, symbol: str, start_date_str: str, skip_confirmation=False
         raise ValueError('entered exchange is not supported')
 
     loop_length = int(candles_count / driver.count) + 1
-    time_to_finish = loop_length * driver.sleep_time / 60
     # ask for confirmation
     if not skip_confirmation:
         click.confirm(
-            'Importing {} days candles from "{}" for "{}". Minimum time it\'ll take '
-            'to finish:"{} minutes" (duplicates will be skipped). All good?'
-                .format(days_count, exchange, symbol, round(time_to_finish, 2)), abort=True, default=True)
+            'Importing {} days candles from "{}" for "{}". Duplicates will be skipped. All good?'
+                .format(days_count, exchange, symbol), abort=True, default=True)
 
     with click.progressbar(length=loop_length, label='Importing candles...') as progressbar:
         for _ in range(candles_count):


### PR DESCRIPTION
Hey guys

I've just been playing around with Jesse today - trying to understand the workings of it etc. I was curious when I imported some candles from Binance how it said it would do three years of data in less than eight minutes - of course it didn't and took closer to 30. 

Just a tiny change - but I've switched the text on this prompt to say "minimum" instead of maximum - as the "time_to_finish" in this file assumes there is no time taken to load the data into the db between each request to the exchange. 

I'm looking to add some exchanges to this - so hopefully you'll see more of me in here with some more interesting PRs!