### PR TITLE
Fix sequential mode for supertrend

### DIFF
--- a/jesse/indicators/supertrend.py
+++ b/jesse/indicators/supertrend.py
@@ -8,7 +8,7 @@ SuperTrend = namedtuple('SuperTrend', ['trend', 'changed'])
 
 def supertrend(candles: np.ndarray, period=10, factor=3, sequential=False) -> SuperTrend:
 
-    if len(candles) > 240:
+    if not sequential and len(candles) > 240:
         candles = candles[-240:]
 
     # calculation of ATR using TALIB function


### PR DESCRIPTION
Supertrend indicator does not implement sequential mode correctly. This is apparent when working in a jupyter notebook, where sequential=True. Current indicator only outputs the last 240 values regardless of the number of candles passed. This should fix it.