### PR TITLE
Add trend change direction output to supertrend

### DIFF
--- a/jesse/indicators/supertrend.py
+++ b/jesse/indicators/supertrend.py
@@ -4,7 +4,7 @@ import talib
 
 from collections import namedtuple
 
-SuperTrend = namedtuple('SuperTrend', ['trend', 'changed'])
+SuperTrend = namedtuple('SuperTrend', ['trend', 'changed', 'change_direction'])
 
 def supertrend(candles: np.ndarray, period=10, factor=3, sequential=False) -> SuperTrend:
 
@@ -21,6 +21,7 @@ def supertrend(candles: np.ndarray, period=10, factor=3, sequential=False) -> Su
     lower_band = lower_basic
     super_trend = np.zeros(len(candles))
     changed = np.zeros(len(candles))
+    change_direction = np.zeros(len(candles))
 
     # calculate the bands:
     # in an UPTREND, lower band does not decrease
@@ -61,18 +62,22 @@ def supertrend(candles: np.ndarray, period=10, factor=3, sequential=False) -> Su
             if candles[:, 2][i] <= currUpperBand:
                 super_trend[i] = currUpperBand  # remain in DOWNTREND
                 changed[i] = False
+                change_direction[i] = 0
             else:
                 super_trend[i] = currLowerBand  # switch to UPTREND
                 changed[i] = True
+                change_direction[i] = 1
         elif prevSuperTrend == prevLowerBand:  # if currently in UPTREND
             if candles[:, 2][i] >= currLowerBand:
                 super_trend[i] = currLowerBand  # remain in UPTREND
                 changed[i] = False
+                change_direction[i] = 0
             else:
                 super_trend[i] = currUpperBand  # switch to DOWNTREND
                 changed[i] = True
+                change_direction[i] = -1
 
     if sequential:
-        return SuperTrend(super_trend, changed)
+        return SuperTrend(super_trend, changed, change_direction)
     else:
-        return SuperTrend(super_trend[-1], changed[-1])
+        return SuperTrend(super_trend[-1], changed[-1], change_direction[-1])


### PR DESCRIPTION
Current trend change output ("changed") of supertrend indicator is not extremely useful, since it does not contain the direction of change, which is a fundamental reason for using such an indicator. While it can be calculated from the indicator values post-hoc, I instead propose adding another output "change_direction" which equals to 1 when the indicator detects a switch from a downtrend to an uptrend and -1 when it detects a switch from an uptrend to a downtrend. This keeps code compatibility intact and only extends the amount of data provided to the user.