### PR TITLE
Parameterize bollinger bands upper, lower, and matype arguments

### DIFF
--- a/jesse/indicators/bollinger_bands.py
+++ b/jesse/indicators/bollinger_bands.py
@@ -6,12 +6,15 @@ from collections import namedtuple
 BollingerBands = namedtuple('BollingerBands', ['upperband', 'middleband', 'lowerband'])
 
 
-def bollinger_bands(candles: np.ndarray, period=20, sequential=False) -> BollingerBands:
+def bollinger_bands(candles: np.ndarray, period=20, devup=2, devdn=2, matype=0, sequential=False) -> BollingerBands:
     """
     BBANDS - Bollinger Bands
 
     :param candles: np.ndarray
     :param period: int - default: 20
+    :param devup: float - default: 2
+    :param devdn: float - default: 2
+    :param matype: int - default: 0
     :param sequential: bool - default=False
 
     :return: BollingerBands
@@ -19,7 +22,7 @@ def bollinger_bands(candles: np.ndarray, period=20, sequential=False) -> Bolling
     if not sequential and len(candles) > 240:
         candles = candles[-240:]
 
-    upperbands, middlebands, lowerbands = talib.BBANDS(candles[:, 2], timeperiod=period, nbdevup=2, nbdevdn=2, matype=0)
+    upperbands, middlebands, lowerbands = talib.BBANDS(candles[:, 2], timeperiod=period, nbdevup=devup, nbdevdn=2, matype=matype)
 
     if sequential:
         return BollingerBands(upperbands, middlebands, lowerbands)

--- a/jesse/indicators/bollinger_bands_width.py
+++ b/jesse/indicators/bollinger_bands_width.py
@@ -4,12 +4,15 @@ import talib
 from typing import Union
 
 
-def bollinger_bands_width(candles: np.ndarray, period=20, sequential=False) -> Union[float, np.ndarray]:
+def bollinger_bands_width(candles: np.ndarray, period=20, devup=2, devdn=2, matype=0, sequential=False) -> Union[float, np.ndarray]:
     """
     BBW - Bollinger Bands Width - Bollinger Bands Bandwidth
 
     :param candles: np.ndarray
     :param period: int - default: 20
+    :param devup: float - default: 2
+    :param devdn: float - default: 2
+    :param matype: int - default: 0
     :param sequential: bool - default=False
 
     :return: float | np.ndarray
@@ -17,7 +20,7 @@ def bollinger_bands_width(candles: np.ndarray, period=20, sequential=False) -> U
     if not sequential and len(candles) > 240:
         candles = candles[-240:]
 
-    upperbands, middlebands, lowerbands = talib.BBANDS(candles[:, 2], timeperiod=period, nbdevup=2, nbdevdn=2, matype=0)
+    upperbands, middlebands, lowerbands = talib.BBANDS(candles[:, 2], timeperiod=period, nbdevup=devup, nbdevdn=devdn, matype=matype)
 
     if sequential:
         return (upperbands - lowerbands) / middlebands


### PR DESCRIPTION
This PR parameterizes bollinger bands' upper and lower bands deviations, as well as the matype.

This will let people use custom values to help optimize strategies for instance, when building for a bear market to avoid buying too early.