### PR TITLE
Kraken exchange: changing driver for candles import

### DIFF
--- a/jesse/modes/import_candles_mode/drivers/kraken.py
+++ b/jesse/modes/import_candles_mode/drivers/kraken.py
@@ -3,6 +3,8 @@ import requests
 import jesse.helpers as jh
 from jesse import exceptions
 from .interface import CandleExchange
+import pandas as pd
+import time
 
 
 class Kraken(CandleExchange):
@@ -12,15 +14,16 @@ class Kraken(CandleExchange):
     """
 
     def __init__(self):
-        super().__init__('Kraken', 720, 5)
-        self.endpoint = 'https://api.kraken.com/0/public/OHLC'
+        # kraken sends as many trades as we wish, although, 
+        # to be on the safe side we will process only 1000 at a time
+        super().__init__('Kraken', 1000, 6)
+        self.endpoint = 'https://api.kraken.com/0/public/Trades'
 
     def init_backup_exchange(self):
         self.backup_exchange = None
 
     def get_starting_time(self, symbol):
         payload = {
-            'interval': '1',
             'pair': symbol,
             'since': 000,
         }
@@ -29,37 +32,63 @@ class Kraken(CandleExchange):
         self._handle_errors(response)
 
         data = response.json()
-        first_timestamp = int(data["result"][self._topair(symbol)][0][0])
-        return first_timestamp * 1000
+        candlesDF = self._tradeconversion(data, symbol, limit=self.count)
+        return candlesDF["timestamp"][0].value
 
     def fetch(self, symbol, start_timestamp):
+        df = self._fetchDF(symbol, start_timestamp)
+        return df.to_dict(orient="records")
+
+    def _fetchDF(self, symbol, start_timestamp):
         payload = {
-            'interval': '1',
             'pair': symbol,
-            'since': start_timestamp / 1000,
+            'since': start_timestamp * 10**6,
         }
 
         response = requests.get(self.endpoint, params=payload)
         self._handle_errors(response)
         data = response.json()["result"][self._topair(symbol)]
-        candles = []
-        for d in data:
-            candles.append({
-                'id': jh.generate_unique_id(),
-                'symbol': symbol,
-                'exchange': self.name,
-                'timestamp': int(d[0]) * 1000,
-                'open': float(d[1]),
-                'close': float(d[4]),
-                'high': float(d[2]),
-                'low': float(d[3]),
-                'volume': float(d[6])
-            })
-
-        return candles
+        candlesDF = self._tradeconversion(data, symbol, limit=self.count)
+        while len(candlesDF.index) < self.count:
+            time.sleep(self.sleep_time)
+            nextTstamp = (candlesDF.index[-1] - pd.Timestamp("1970-01-01")) // pd.Timedelta("1ns")
+            payload["since"] = nextTstamp
+            response = requests.get(self.endpoint, params=payload)
+            self._handle_errors(response)
+            data = response.json()["result"][self._topair(symbol)]
+            nextCandlesDF = self._tradeconversion(data, symbol, limit=self.count)
+            nextCandlesDF.drop(candlesDF.index, inplace=True, errors="ignore")
+            candlesDF = candlesDF.append(nextCandlesDF, sort=True)
+        return candlesDF
 
     def _topair(self, symbol):
         return "X{}Z{}".format(symbol[:3], symbol[3:]).upper()
+
+    def _tradeconversion(self, data, symbol, limit=-1):
+        # if no limit given, we discard the last candle anyway
+        trades = []
+        volumes = []
+        tstamps = []
+        for trade in data:
+            trades.append(float(trade[0]))
+            volumes.append(float(trade[1]))
+            tstamps.append(pd.to_datetime(trade[2], unit="s"))
+        tradeSeries = pd.Series(data=trades, index=tstamps)
+        volumeSeries = pd.Series(data=volumes, index=tstamps)
+        grouper = pd.Grouper(freq="1Min", base=0)
+        vols = volumeSeries.groupby(grouper).sum()
+        trds = tradeSeries.groupby(grouper).ohlc()
+        candls = trds
+        candls.loc[:, "volume"] = vols
+        # always throw away the last candle
+        candls = candls[0:-1]
+        candls = candls[0:limit]
+        candls = candls.fillna(method="ffill")
+        candls.loc[:, "id"] = [jh.generate_unique_id() for idx in range(len(candls.index))]
+        candls.loc[:, "symbol"] = symbol
+        candls.loc[:, "exchange"] = self.name
+        candls.loc[:, "timestamp"] = (candls.index - pd.Timestamp("1970-01-01")) // pd.Timedelta("1ms")
+        return candls
 
     @staticmethod
     def _handle_errors(response):


### PR DESCRIPTION
Kraken limits OHLC data to only the last 720 points at the given time
interval, for 1minute interval it means only last 12hours.
On the other hand, kraken provides full history of all the trades done
in the platform.
This commit changes the driver for importing candles, it exploit trades
history to create ohlc data at 1Min intervals.


Alright,
checked timestamps twice.
This is an example of lines in db
```
jesse_test_db=# select * from candle order by timestamp limit 3;
                  id                  |   timestamp   |  open  | close  |  high  |  low   |  volume  | symbol | exchange 
--------------------------------------+---------------+--------+--------+--------+--------+----------+--------+----------
 f29d3454-02ff-4e71-a59a-a4aa6472409f | 1592006400000 | 8417.1 | 8417.1 | 8417.1 | 8417.1 |        0 | XBTEUR | Kraken
 0b6be84a-a6df-480f-ac98-d0555c6ac6c8 | 1592006460000 | 8417.1 | 8419.1 | 8419.1 | 8417.1 | 0.868631 | XBTEUR | Kraken
 ab561bee-92e4-452c-81c1-ebc0de489ada | 1592006520000 | 8417.6 | 8417.7 | 8417.7 | 8417.6 | 0.010073 | XBTEUR | Kraken
```
Although, given the way candles are built, there might be issues with the start and final timestamp, let me know if that might be a problem or jesse can handle this.