### PR TITLE
numpy_candles_to_dataframe: candles timestamp to pandas.Datetime

### DIFF
--- a/jesse/utils.py
+++ b/jesse/utils.py
@@ -185,5 +185,6 @@ def crossed(series1: np.ndarray, series2: Union[float, int, np.ndarray], directi
 def numpy_candles_to_dataframe(candles: np.ndarray, name_date="date", name_open="open", name_high="high",
                                name_low="low", name_close="close", name_volume="volume") -> pd.DataFrame:
     columns = [name_date, name_open, name_close, name_high, name_low, name_volume]
-    df = pd.DataFrame(data=candles, index=candles[:, 0], columns=columns)
+    df = pd.DataFrame(data=candles, index=pd.to_datetime(candles[:, 0], unit="ms"), columns=columns)
+    df[name_date] = pd.to_datetime(df.index, unit="ms")
     return df

--- a/tests/test_strategy_utils.py
+++ b/tests/test_strategy_utils.py
@@ -112,7 +112,8 @@ def test_crossed():
 def test_numpy_to_pandas():
     candles = np.array(mama_candles)
     columns = ["Date", "Open", "Close", "High", "Low", "Volume"]
-    df = pd.DataFrame(data=candles, index=candles[:, 0], columns=columns)
+    df = pd.DataFrame(data=candles, index=pd.to_datetime(candles[:, 0], unit="ms"), columns=columns)
+    df["Date"] = pd.to_datetime(df["Date"], unit="ms")
 
     ohlcv = utils.numpy_candles_to_dataframe(candles, name_date="Date", name_open="Open", name_high="High",
                                              name_low="Low", name_close="Close", name_volume="Volume")


### PR DESCRIPTION
When converting candles into a dataframe, it would be nice to use pandas
datetime index rather than timestamp epoch.
This commit changes the utils function to convert epoch values to pandas
datetimes, tests are changed accordingly