### PR TITLE
Adding plugins system for candles-import-driver

### DIFF
--- a/jesse/__init__.py
+++ b/jesse/__init__.py
@@ -355,6 +355,24 @@ def optimize(start_date, finish_date, optimal_total, cpu, debug):
 
 @cli.command()
 @click.argument('name', required=True, type=str)
+def make_candleImportDriver(name):
+    """
+    generates a new driver for importing candles in jesse/plugins/import-candles-drivers
+    """
+    validate_cwd()
+    from jesse.config import config
+
+    config['app']['trading_mode'] = 'make-candleimportdriver'
+
+    register_custom_exception_handler()
+
+    from jesse.services import candleimportdriver_maker
+
+    candleimportdriver_maker.generate(name)
+
+
+@cli.command()
+@click.argument('name', required=True, type=str)
 def make_strategy(name):
     """
     generates a new strategy folder from jesse/strategies/ExampleStrategy

--- a/jesse/exceptions/__init__.py
+++ b/jesse/exceptions/__init__.py
@@ -65,5 +65,10 @@ class ConfigException(Exception):
 class InvalidTimeframe(Exception):
     pass
 
+
 class NegativeBalance(Exception):
+    pass
+
+
+class InvalidCandleImportDriver(Exception):
     pass

--- a/jesse/modes/import_candles_mode/__init__.py
+++ b/jesse/modes/import_candles_mode/__init__.py
@@ -9,7 +9,7 @@ import pydash
 import jesse.helpers as jh
 from jesse.exceptions import CandleNotFoundInExchange
 from jesse.models import Candle
-from jesse.modes.import_candles_mode.drivers import drivers
+from jesse.modes.import_candles_mode.drivers import get_driver
 from jesse.modes.import_candles_mode.drivers.interface import CandleExchange
 
 
@@ -36,7 +36,7 @@ def run(exchange: str, symbol: str, start_date_str: str, skip_confirmation=False
     exchange = exchange.title()
 
     try:
-        driver: CandleExchange = drivers[exchange]()
+        driver: CandleExchange = get_driver(exchange)()
     except KeyError:
         raise ValueError('{} is not a supported exchange'.format(exchange))
 

--- a/jesse/modes/import_candles_mode/drivers/__init__.py
+++ b/jesse/modes/import_candles_mode/drivers/__init__.py
@@ -3,6 +3,10 @@ from .binance_futures import BinanceFutures
 from .bitfinex import Bitfinex
 from .coinbase import Coinbase
 from .testnet_binance_futures import TestnetBinanceFutures
+import jesse.helpers as jh
+from jesse import exceptions
+from pydoc import locate
+import sys
 
 drivers = {
     'Binance': Binance,
@@ -11,3 +15,23 @@ drivers = {
     'Bitfinex': Bitfinex,
     'Coinbase': Coinbase,
 }
+
+
+def get_driver(name: str):
+    if name in drivers.keys():
+        return drivers[name]
+    if jh.is_unit_testing():
+        exists = jh.file_exists(sys.path[0] + '/jesse/modes/import_candles_mode/drivers/{}.py'.format(name.lower()))
+        driver_class_path = 'jesse.modes.import_candles_mode.drivers.{}.{}'.format(name.lower(), name)
+    else:
+        exists = jh.file_exists('plugins/CandlesImportDrivers/{}.py'.format(name.lower()))
+        driver_class_path = 'plugins.CandlesImportDrivers.{}.{}'.format(name.lower(), name)
+
+    if not exists:
+        raise exceptions.InvalidRoutes(
+            'A Driver with the name of "{}" could not be found.'.format(name))
+    return locate(driver_class_path)
+
+
+
+

--- a/jesse/services/candleimportdriver_maker/CandlesImportDrivers/DummyDriver.py
+++ b/jesse/services/candleimportdriver_maker/CandlesImportDrivers/DummyDriver.py
@@ -1,0 +1,28 @@
+
+import numpy as np
+from jesse.interface import CandleExchange
+
+
+class DummyDriver(CandleExchange):
+    """
+    """
+
+    def __init__(self):
+        super().__init__("DummyDriver", 10, 0)
+
+    def init_backup_exchange(self):
+        """
+        """
+        self.backup_exchange = None
+
+    def get_starting_time(self, symbol) -> int:
+        """
+        :param symbol:
+        :return:
+        """
+        return 0
+
+    def fetch(self, symbol, start_timestamp) -> np.ndarray:
+        """
+        """
+        return np.ndarray()

--- a/jesse/services/candleimportdriver_maker/__init__.py
+++ b/jesse/services/candleimportdriver_maker/__init__.py
@@ -1,0 +1,35 @@
+import os
+import shutil
+
+import jesse.helpers as jh
+
+
+def generate(name):
+    """
+
+    :param name:
+    :return:
+    """
+    path = 'plugins/CandlesImportDrivers'
+    driverfullpathname = os.path.join(path, "{}.py".format(name.lower()))
+    # validation for name duplication
+    exists = os.path.isdir(driverfullpathname)
+    if exists:
+        print(jh.color('Driver "{}" for importing candles already exists.'.format(name), 'red'))
+        return
+
+    # generate from ExampleStrategy
+    dirname, filename = os.path.split(os.path.abspath(__file__))
+
+    if not os.path.exists(path):
+        os.makedirs(path)
+    shutil.copyfile('{}/CandlesImportDrivers/DummyDriver.py'.format(dirname), driverfullpathname)
+
+    # replace 'DummyDriver' with the name of the new driver
+    fin = open(driverfullpathname, "rt")
+    data = fin.read()
+    data = data.replace('DummyDriver', name.title())
+    fin.close()
+    fin = open(driverfullpathname, "wt")
+    fin.write(data)
+    fin.close()


### PR DESCRIPTION
In an effort to let jesse users develop their own drivers for
exchanges, this commit adds a first draft of a plugin system that is
capable of dynamically importing user-developed driver for importing
candles from an "exotic" exchange.

As for strategies, jesse provides a cammand
$ jesse make-candleimportdriver <DriverName>
that initializes the plugin system for CandleImporters and compiles a
dummy implementation of <DriverName>