### PR TITLE
Ensure there's a log folder before attaching log handler

### DIFF
--- a/jesse/__init__.py
+++ b/jesse/__init__.py
@@ -82,6 +82,7 @@ def register_custom_exception_handler():
     from jesse import exceptions
 
     log_format = "%(message)s"
+    os.makedirs('storage/logs', exist_ok=True)
 
     if jh.is_livetrading():
         logging.basicConfig(filename='storage/logs/live-trade.txt', level=logging.INFO, filemode='w', format=log_format)


### PR DESCRIPTION
When I ran the optimizer for the first time, I got `FileNotFoundError: [Errno 2] No such file or directory: '<path>/storage/logs/optimize.txt`. It was fixed by adding a `logs` folder, so I added a call to `os.makedirs` right before the handler would be attached.