### PR TITLE
Adding if cases for EUR in helpers functions

### DIFF
--- a/jesse/helpers.py
+++ b/jesse/helpers.py
@@ -31,9 +31,9 @@ def base_asset(symbol: str):
     if symbol.endswith('USDT'):
         return symbol[0:len(symbol) - 4]
 
-    if symbol.endswith('USD'):
+    bases = map(symbol.endswith, ['USD', 'EUR', 'GBP', 'BNB'])
+    if any(bases):
         return symbol[0:len(symbol) - 3]
-
     return symbol[0:3]
 
 
@@ -503,10 +503,11 @@ def quote_asset(symbol: str):
     if symbol.endswith('USDT'):
         return 'USDT'
 
-    if symbol.endswith('USD'):
-        return 'USD'
+    bases = map(symbol.endswith, ['USD', 'EUR', 'GBP', 'BNB'])
+    if any(bases):
+        return symbol[-3:]
 
-    return symbol[3:]
+    return symbol[-3:]
 
 
 def random_str(num_characters=8):

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -26,8 +26,14 @@ def test_arrow_to_timestamp():
 def test_base_asset():
     assert jh.base_asset('BTCUSDT') == 'BTC'
     assert jh.base_asset('BTCUSD') == 'BTC'
+    assert jh.base_asset('BTCBNB') == 'BTC'
+    assert jh.base_asset('BTCEUR') == 'BTC'
+    assert jh.base_asset('BTCGBP') == 'BTC'
     assert jh.base_asset('DEFIUSDT') == 'DEFI'
     assert jh.base_asset('DEFIUSD') == 'DEFI'
+    assert jh.base_asset('DEFIBNB') == 'DEFI'
+    assert jh.base_asset('DEFIEUR') == 'DEFI'
+    assert jh.base_asset('DEFIGBP') == 'DEFI'
 
 
 def test_binary_search():
@@ -399,7 +405,15 @@ def test_python_version():
 
 def test_quote_asset():
     assert jh.quote_asset('BTCUSDT') == 'USDT'
+    assert jh.quote_asset('BTCUSD') == 'USD'
+    assert jh.quote_asset('BTCBNB') == 'BNB'
+    assert jh.quote_asset('BTCEUR') == 'EUR'
+    assert jh.quote_asset('BTCGBP') == 'GBP'
     assert jh.quote_asset('DEFIUSDT') == 'USDT'
+    assert jh.quote_asset('DEFIUSD') == 'USD'
+    assert jh.quote_asset('DEFIBNB') == 'BNB'
+    assert jh.quote_asset('DEFIEUR') == 'EUR'
+    assert jh.quote_asset('DEFIGBP') == 'GBP'
 
 
 def test_random_str():


### PR DESCRIPTION
In functions base_asset and quote_asset there are special if cases for
USDT and USD, this commit refactors the functions to accept easily any
other special cases like EUR GBP or BNB.