### PR TITLE
Adding support for unknown driver symbol start_date

### DIFF
--- a/jesse/helpers.py
+++ b/jesse/helpers.py
@@ -660,6 +660,9 @@ def timestamp_to_date(timestamp: int) -> str:
 def timestamp_to_time(timestamp) -> str:
     return str(arrow.get(timestamp / 1000))
 
+def next_date(datestr: str) -> str:
+    return timestamp_to_date(arrow_to_timestamp(arrow.get(datestr, 'YYYY-MM-DD').shift(days=1)))
+
 
 def today_to_timestamp() -> int:
     """

--- a/jesse/modes/import_candles_mode/__init__.py
+++ b/jesse/modes/import_candles_mode/__init__.py
@@ -78,12 +78,13 @@ def run(exchange: str, symbol: str, start_date_str: str, skip_confirmation=False
 
                     # if driver can't provide accurate get_starting_time()
                     if first_existing_timestamp is None:
-                        raise CandleNotFoundInExchange(
-                            'No candles exists in the market for this day: {} \n'
-                            'Try another start_date'.format(
+                        print(
+                            'No candles exists in the market for this day: {} - attempting next date.'.format(
                                 jh.timestamp_to_time(temp_start_timestamp)[:10],
                             )
                         )
+                        time.sleep(driver.sleep_time)
+                        run(exchange, symbol, jh.next_date(start_date_str), skip_confirmation=True)
 
                     # handle when there's missing candles during the period
                     if temp_start_timestamp > first_existing_timestamp:


### PR DESCRIPTION
 * Coinbase, for example, has hardcoded start times (due to api functionality)
 * For unknown start dates, the driver will attempt to import candles for the next date
 * Rather than throwing an error, this change can assist users in finding the true start date for a given symbol