### PR TITLE
Only use integers in readable_duration output

### DIFF
--- a/jesse/helpers.py
+++ b/jesse/helpers.py
@@ -538,6 +538,7 @@ def readable_duration(seconds: int, granularity: int = 2) -> str:
     )
 
     result = []
+    seconds = int(seconds)
 
     for name, count in intervals:
         value = seconds // count


### PR DESCRIPTION
While typed as `int`, the seconds parameter is often passed in as a float in reports, leading to outputs like this:

```python
readable_duration(184722.0, 3)
# 2.0 days, 3.0 hours, 18.0 minutes
```

This is neither pretty nor correct, converting seconds to integer first always gives us the desired output:

```python
readable_duration(184722.0, 3)
# 2 days, 3 hours, 18 minutes
```