### PR TITLE
Ability to generate QuantStats' report

### DIFF
--- a/jesse/__init__.py
+++ b/jesse/__init__.py
@@ -288,8 +288,10 @@ def import_candles(exchange: str, symbol: str, start_date: str, skip_confirmatio
               help='Generates charts of daily portfolio balance and assets price change. Useful for a visual comparision of your portfolio against the market.')
 @click.option('--tradingview/--no-tradingview', default=False,
               help="Generates an output that can be copy-and-pasted into tradingview.com's pine-editor too see the trades in their charts.")
+@click.option('--full-reports/--no-full-reports', default=False,
+              help="Generates QuantStats' HTML output with metrics reports like Sharpe ratio, Win rate, Volatility, etc., and batch plotting for visualizing performance, drawdowns, rolling statistics, monthly returns, etc.")
 def backtest(start_date: str, finish_date: str, debug: bool, csv: bool, json: bool, fee: bool, chart: bool,
-             tradingview: bool) -> None:
+             tradingview: bool, full_reports: bool) -> None:
     """
     backtest mode. Enter in "YYYY-MM-DD" "YYYY-MM-DD"
     """
@@ -314,7 +316,7 @@ def backtest(start_date: str, finish_date: str, debug: bool, csv: bool, json: bo
             get_exchange(e).fee = 0
 
     backtest_mode.run(start_date, finish_date, chart=chart, tradingview=tradingview, csv=csv,
-                      json=json)
+                      json=json, full_reports=full_reports)
 
     db.close_connection()
 

--- a/jesse/modes/backtest_mode/__init__.py
+++ b/jesse/modes/backtest_mode/__init__.py
@@ -17,6 +17,7 @@ from jesse.models import Candle
 from jesse.modes.utils import save_daily_portfolio_balance
 from jesse.routes import router
 from jesse.services import charts
+from jesse.services import quantstats
 from jesse.services import report
 from jesse.services.cache import cache
 from jesse.services.candle import generate_candle_from_one_minutes, print_candle, candle_includes_price, split_candle
@@ -26,7 +27,7 @@ from jesse.store import store
 
 
 def run(start_date: str, finish_date: str, candles: Dict[str, Dict[str, Union[str, np.ndarray]]] = None,
-        chart: bool = False, tradingview: bool = False,
+        chart: bool = False, tradingview: bool = False, full_reports: bool = False,
         csv: bool = False, json: bool = False) -> None:
     # clear the screen
     if not jh.should_execute_silently():
@@ -99,6 +100,10 @@ def run(start_date: str, finish_date: str, candles: Dict[str, Dict[str, Union[st
 
             if chart:
                 charts.portfolio_vs_asset_returns()
+
+            # QuantStats' report
+            if full_reports:
+                quantstats.quantstats_tearsheet()
         else:
             print(jh.color('No trades were made.', 'yellow'))
 

--- a/jesse/services/quantstats.py
+++ b/jesse/services/quantstats.py
@@ -1,0 +1,37 @@
+import os
+from datetime import datetime, timedelta
+
+import arrow
+import quantstats as qs
+import pandas as pd
+
+from jesse.store import store
+from jesse.config import config
+
+
+def quantstats_tearsheet() -> None:
+	daily_returns = pd.Series(store.app.daily_balance).pct_change(1).values
+
+	start_date = datetime.fromtimestamp(store.app.starting_time / 1000)
+	date_list = [start_date + timedelta(days=x) for x in range(len(store.app.daily_balance))]
+
+	returns_time_series = pd.Series(daily_returns, index=pd.to_datetime(list(date_list)))
+
+	mode = config['app']['trading_mode']
+	modes = {
+		'backtest': ['BT', 'Backtest'],
+		'livetrade': ['LT', 'LiveTrade'],
+		'papertrade': ['PT', 'PaperTrade']
+	}
+
+	os.makedirs('./storage/full-reports', exist_ok=True)
+
+	file_path = 'storage/full-reports/{}-{}.html'.format(
+		modes[mode][0], str(arrow.utcnow())[0:19]
+	).replace(":", "-")
+
+	title = '{} → {}'.format(modes[mode][1], arrow.utcnow().strftime("%d %b, %Y %H:%M:%S"))
+
+	qs.reports.html(returns=returns_time_series, title=title, output=file_path)
+
+	print('\nFull report output saved at:\n{}'.format(file_path))

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ TA-Lib==0.4.19
 tabulate==0.8.9
 timeloop==1.0.2
 websocket-client==0.58.0
+quantstats==0.0.26


### PR DESCRIPTION
The goal is to get quantstats' HTML report file using the [QuantStats](https://github.com/ranaroussi/quantstats) library after backtest ends.
[View original html file](https://rawcdn.githack.com/ranaroussi/quantstats/bd0e70bd284798a58c569363bc7e1c3c8c6e3fd9/docs/tearsheet.html). 

Example of use: 
`jesse backtest '2019-01-01' '2019-10-30' --full-reports`