### PR TITLE
Fix first_timestamp for Binance drivers

### DIFF
--- a/jesse/modes/import_candles_mode/drivers/binance.py
+++ b/jesse/modes/import_candles_mode/drivers/binance.py
@@ -17,7 +17,7 @@ class Binance(CandleExchange):
         dashless_symbol = jh.dashless_symbol(symbol)
 
         payload = {
-            'interval': '1d',
+            'interval': '1M',
             'symbol': dashless_symbol,
             'limit': 1500,
         }

--- a/jesse/modes/import_candles_mode/drivers/binance_futures.py
+++ b/jesse/modes/import_candles_mode/drivers/binance_futures.py
@@ -18,7 +18,7 @@ class BinanceFutures(CandleExchange):
         dashless_symbol = jh.dashless_symbol(symbol)
 
         payload = {
-            'interval': '1d',
+            'interval': '1M',
             'symbol': dashless_symbol,
             'limit': 1500,
         }

--- a/jesse/modes/import_candles_mode/drivers/binance_inverse_futures.py
+++ b/jesse/modes/import_candles_mode/drivers/binance_inverse_futures.py
@@ -16,7 +16,7 @@ class BinanceInverseFutures(CandleExchange):
 
     def get_starting_time(self, symbol):
         payload = {
-            'interval': '1d',
+            'interval': '1M',
             'symbol': encode_symbol(symbol),
             'limit': 1500,
         }


### PR DESCRIPTION
when import candles with
`jesse import-candles Binance BTC-USDT 2010-01-01`

before:
`First present candle is since 2018-07-08. Would you like to continue? [Y/n]:`

after:
`First present candle is since 2017-08-02. Would you like to continue? [Y/n]:`
