### PR TITLE
docker: Switch to slim image and update python version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.9.0
+FROM python:3.9.4-slim
 ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update \

--- a/DockerfileTest
+++ b/DockerfileTest
@@ -1,4 +1,4 @@
-FROM python:3.9.0
+FROM python:3.9.4-slim
 ENV PYTHONUNBUFFERED 1
 
 RUN apt-get update \


### PR DESCRIPTION
- Switch to slim variant of the image
-> Reduces container image size from 1.5GB to 0.9GB (40% reduction)
- Updates Python to 3.9.4