### PR TITLE
config key with space from env

### DIFF
--- a/jesse/helpers.py
+++ b/jesse/helpers.py
@@ -260,8 +260,8 @@ def get_config(keys: str, default: Any = None) -> Any:
         raise ValueError('keys string cannot be empty')
 
     if is_unit_testing() or not keys in CACHED_CONFIG:
-        if os.environ.get(keys.upper().replace(".", "_").replace(" ", "_")) is not None:
-            CACHED_CONFIG[keys] = os.environ.get(keys.upper().replace(".", "_").replace(" ", "_"))
+        if os.getenv(keys.upper().replace(".", "_").replace(" ", "_")) is not None:
+            CACHED_CONFIG[keys] = os.getenv(keys.upper().replace(".", "_").replace(" ", "_"))
         else:
             from functools import reduce
             from jesse.config import config

--- a/jesse/helpers.py
+++ b/jesse/helpers.py
@@ -260,8 +260,8 @@ def get_config(keys: str, default: Any = None) -> Any:
         raise ValueError('keys string cannot be empty')
 
     if is_unit_testing() or not keys in CACHED_CONFIG:
-        if os.getenv(keys.upper().replace(".", "_").replace(" ", "_")) is not None:
-            CACHED_CONFIG[keys] = os.getenv(keys.upper().replace(".", "_").replace(" ", "_"))
+        if os.environ.get(keys.upper().replace(".", "_").replace(" ", "_")) is not None:
+            CACHED_CONFIG[keys] = os.environ.get(keys.upper().replace(".", "_").replace(" ", "_"))
         else:
             from functools import reduce
             from jesse.config import config

--- a/jesse/helpers.py
+++ b/jesse/helpers.py
@@ -260,8 +260,8 @@ def get_config(keys: str, default: Any = None) -> Any:
         raise ValueError('keys string cannot be empty')
 
     if is_unit_testing() or not keys in CACHED_CONFIG:
-        if os.environ.get(keys.upper().replace(".", "_")) is not None:
-            CACHED_CONFIG[keys] = os.environ.get(keys.upper().replace(".", "_"))
+        if os.environ.get(keys.upper().replace(".", "_").replace(" ", "_")) is not None:
+            CACHED_CONFIG[keys] = os.environ.get(keys.upper().replace(".", "_").replace(" ", "_"))
         else:
             from functools import reduce
             from jesse.config import config

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -211,10 +211,14 @@ def test_get_config(monkeypatch):
     assert jh.get_config('aaaaaaa', 2020) == 2020
     # assert when config does exist
     assert jh.get_config('env.logging.order_submission', 2020) is True
-    # assert env is taked
+    # assert env is took
     monkeypatch.setenv("ENV_DATABASES_POSTGRES_HOST", "db")
     assert jh.get_config('env.databases.postgres_host', 'default') == 'db'
     monkeypatch.delenv("ENV_DATABASES_POSTGRES_HOST")
+    # assert env is took with space
+    monkeypatch.setenv("ENV_EXCHANGES_BINANCE_FUTURES_SETTLEMENT_CURRENCY", 'BUSD')
+    assert jh.get_config('env.exchanges.Binance Futures.settlement_currency', 'USDT') == 'BUSD'
+    monkeypatch.delenv("ENV_EXCHANGES_BINANCE_FUTURES_SETTLEMENT_CURRENCY")
 
 
 def test_get_strategy_class():


### PR DESCRIPTION
Motivation is to be able to inject env variables into the config where the key contains space like example: `env.exchanges.Binance Futures.settlement_currency` 