### PR TITLE
Cancel open orders in the liquidation events.

### DIFF
--- a/jesse/strategies/Strategy.py
+++ b/jesse/strategies/Strategy.py
@@ -147,6 +147,8 @@ class Strategy(ABC):
             self._on_take_profit(order)
         elif role == order_roles.CLOSE_POSITION and order in self._stop_loss_orders:
             self._on_stop_loss(order)
+        elif role == order_roles.CLOSE_POSITION:
+            self._execute_cancel()
         elif role == order_roles.INCREASE_POSITION:
             self._on_increased_position(order)
         elif role == order_roles.REDUCE_POSITION:


### PR DESCRIPTION
Fixes: #210

From my previous pull request:

Responsible function for closing open orders is => `Strategy._execute_cancel()`. Called from;

- `Strategy._check()` => `Strategy._execute()` : On new candle - This won't help us, since liquidation events happens at random time. Moving on:
- `Strategy._on_stop_loss()` and `Strategy._on_take_profit()` => `Strategy.__on_updated_position` => `Position._on_executed_order`  => `Order.execute()`. So This must be it.


When `_check_for_liquidations` => `Order.execute()` => `Position._on_executed_order` => `Strategy._on_updated_position` happens, the problem is in the following lines:

```python
146:        elif role == order_roles.CLOSE_POSITION and order in self._take_profit_orders:
147:            self._on_take_profit(order)
148:        elif role == order_roles.CLOSE_POSITION and order in self._stop_loss_orders:
149:            self._on_stop_loss(order)
```

`role == CLOSE_POSITION` true but liquidation order is neither in `self._stop_loss_orders` nor `self._take_profit_orders`.

So possible solution might be adding the liquidation order into `self._stop_loss_orders` but it might break something else. Since liquidation != stop loss. I think a better solution would be something like;

```python
146:        elif role == order_roles.CLOSE_POSITION and order in self._take_profit_orders:
147:            self._on_take_profit(order)
148:        elif role == order_roles.CLOSE_POSITION and order in self._stop_loss_orders:
149:            self._on_stop_loss(order)
150:        elif role == order_roles.CLOSE_POSITION:
151:            self._execute_cancel()
```

_Originally posted by @farukuzun in https://github.com/jesse-ai/jesse/issues/211#issuecomment-869123038_