### PR TITLE
Unlock access to older kline data for Binance Spot

### DIFF
--- a/jesse/modes/import_candles_mode/drivers/binance.py
+++ b/jesse/modes/import_candles_mode/drivers/binance.py
@@ -20,9 +20,9 @@ class Binance(CandleExchange):
         dashless_symbol = jh.dashless_symbol(symbol)
 
         payload = {
-            'interval': '1d',
+            'interval': '3d',
             'symbol': dashless_symbol,
-            'limit': 1500,
+            'limit': 1000,
         }
 
         response = requests.get(self.endpoint, params=payload)


### PR DESCRIPTION
Using 3d interval to get starting time helps to access older data. Also payload limited to 1000 as default by Binance.

Before:
```console
$ jesse import-candles Binance BTC-USDT 2016-01-01
No candle exists in the market for 2016-01-01

First present candle is since 2019-02-15. Would you like to continue? [Y/n]: 
```

After:
```console
$ jesse import-candles Binance BTC-USDT 2016-01-01
No candle exists in the market for 2016-01-01

First present candle is since 2017-08-18. Would you like to continue? [Y/n]: 
```