### PR TITLE
removes exchange.title() transformation in research/get_candles.py

### DIFF
--- a/jesse/research/get_candles.py
+++ b/jesse/research/get_candles.py
@@ -13,7 +13,6 @@ def get_candles(exchange: str, symbol: str, timeframe: str, start_date: str, fin
     
     :return: np.ndarray
     """
-    exchange = exchange.title()
     symbol = symbol.upper()
 
     import arrow


### PR DESCRIPTION
This PR removes the titleization of the exchange name string in the function `get_candles` in research/get_candles.py and fixes `CandleNotFoundInDatabase` when using an exchange containing uppercases in its name, for ex the new 'FTX Futures'  exchange.