### PR TITLE
supports custom redis database number by passing REDIS_DB throught environment

### DIFF
--- a/jesse/services/env.py
+++ b/jesse/services/env.py
@@ -23,6 +23,7 @@ if jh.is_jesse_project():
         ENV_VALUES['POSTGRES_PASSWORD'] = 'password'
         ENV_VALUES['REDIS_HOST'] = 'localhost'
         ENV_VALUES['REDIS_PORT'] = '6379'
+        ENV_VALUES['REDIS_DB'] = 0
         ENV_VALUES['REDIS_PASSWORD'] = ''
 
     # validation for existence of .env file

--- a/jesse/services/redis.py
+++ b/jesse/services/redis.py
@@ -12,6 +12,7 @@ async def init_redis():
     return await aioredis.create_redis_pool(
         address=(ENV_VALUES['REDIS_HOST'], ENV_VALUES['REDIS_PORT']),
         password=ENV_VALUES['REDIS_PASSWORD'] or None,
+        db=int(ENV_VALUES.get('REDIS_DB') or 0),
     )
 
 
@@ -21,7 +22,7 @@ if jh.is_jesse_project():
     if not jh.is_notebook():
         async_redis = asyncio.run(init_redis())
         sync_redis = sync_redis_lib.Redis(
-            host=ENV_VALUES['REDIS_HOST'], port=ENV_VALUES['REDIS_PORT'], db=0,
+            host=ENV_VALUES['REDIS_HOST'], port=ENV_VALUES['REDIS_PORT'], db=int(ENV_VALUES.get('REDIS_DB') or 0),
             password=ENV_VALUES['REDIS_PASSWORD'] if ENV_VALUES['REDIS_PASSWORD'] else None
         )
 


### PR DESCRIPTION
As the title mention, this MR allow to use a redis database different than the default 0.

This can be usefull if using a redis instance outside of docker for example, or to be able to use multiple instances of jesse.

Code is backward compatible if the key is missing in the conf, `KeyError` are avoided by using `ENV_VALUES.get`.
