### PR TITLE
Fix shared dictionaries over different instances

### DIFF
--- a/jesse/models/Exchange.py
+++ b/jesse/models/Exchange.py
@@ -4,22 +4,18 @@ from jesse.models import Order
 
 
 class Exchange(ABC):
-    name = ''
-    fee_rate = None
-
-    # current holding assets
-    assets = {}
-    # used for calculating available balance in futures mode:
-    temp_reduced_amount = {}
-    # current available assets (dynamically changes based on active orders)
-    available_assets = {}
-    # used for calculating final performance metrics
-    starting_assets = {}
-
-    # some exchanges might require even further info
-    vars = {}
-
     def __init__(self, name: str, starting_assets: list, fee_rate: float, exchange_type: str):
+        # current holding assets
+        self.assets = {}
+        # used for calculating available balance in futures mode:
+        self.temp_reduced_amount = {}
+        # current available assets (dynamically changes based on active orders)
+        self.available_assets = {}
+        # used for calculating final performance metrics
+        self.starting_assets = {}
+
+        # some exchanges might require even further info
+        self.vars = {}
         self.name = name
         self.type = exchange_type.lower()
 

--- a/jesse/models/FuturesExchange.py
+++ b/jesse/models/FuturesExchange.py
@@ -11,24 +11,6 @@ from .Exchange import Exchange
 
 
 class FuturesExchange(Exchange):
-    # # used for live-trading only:
-    # in futures trading, margin is only with one asset, so:
-    _available_margin = 0
-    # in futures trading, wallet is only with one asset, so:
-    _wallet_balance = 0
-    # so is started_balance
-    _started_balance = 0
-
-    # current holding assets
-    assets = {}
-    # current available assets (dynamically changes based on active orders)
-    available_assets = {}
-    # used to estimating metrics
-    starting_assets = {}
-
-    buy_orders = {}
-    sell_orders = {}
-
     def __init__(
             self,
             name: str,
@@ -38,6 +20,23 @@ class FuturesExchange(Exchange):
             futures_leverage_mode: str,
             futures_leverage: int
     ):
+        # # used for live-trading only:
+        # in futures trading, margin is only with one asset, so:
+        self._available_margin = 0
+        # in futures trading, wallet is only with one asset, so:
+        self._wallet_balance = 0
+        # so is started_balance
+        self._started_balance = 0
+
+        # current holding assets
+        self.assets = {}
+        # current available assets (dynamically changes based on active orders)
+        self.available_assets = {}
+        # used to estimating metrics
+        self.starting_assets = {}
+
+        self.buy_orders = {}
+        self.sell_orders = {}
         super().__init__(name, starting_assets, fee_rate, 'futures')
 
         self.futures_leverage_mode = futures_leverage_mode

--- a/jesse/models/SpotExchange.py
+++ b/jesse/models/SpotExchange.py
@@ -13,12 +13,11 @@ class SpotExchange(Exchange):
     def charge_fee(self, amount: float) -> None:
         pass
 
-    # current holding assets
-    assets = {}
-    # current available assets (dynamically changes based on active orders)
-    available_assets = {}
-
     def __init__(self, name: str, starting_assets: list, fee_rate: float):
+        # current holding assets
+        self.assets = {}
+        # current available assets (dynamically changes based on active orders)
+        self.available_assets = {}
         super().__init__(name, starting_assets, fee_rate, 'spot')
 
         from jesse.routes import router


### PR DESCRIPTION
Its the same problem as the lists which where defined in the header of the class. Those lists and dicts get shard over different instances when those classes are called via the research module in optuna or hyperactive. This will prevent the optimization getting super slow. 

This is one of my first PR. So i hope i am doing this correct! 