### PR TITLE
fetch entry price from live stream to avoid self.average_entry_price = None upon session restart

### DIFF
--- a/jesse/strategies/Strategy.py
+++ b/jesse/strategies/Strategy.py
@@ -1007,6 +1007,9 @@ class Strategy(ABC):
 
     @property
     def average_entry_price(self) -> float:
+        if jh.is_livetrading():
+            return self.position.entry_price
+
         if self.is_long:
             arr = self._buy
         elif self.is_short:


### PR DESCRIPTION
in live trading, if a session is restarted while there is an opening position, `self.average_entry_price` will be `None` and it impacts failure to compute liquidation price.
`self.average_entry_price` becomes `None` because `Strategy`'s intermediate attributes like `self._buy`, `self._sell` etc are reset to be `None`. I think a better way to address it is to let `self.average_entry_price` fetch the entry price from live stream data instead.