### PR TITLE
import_candles() requires recursive run() to be returned

### DIFF
--- a/jesse/modes/import_candles_mode/__init__.py
+++ b/jesse/modes/import_candles_mode/__init__.py
@@ -161,7 +161,7 @@ def run(
             })
         elif show_progressbar:
             jh.clear_output()
-            print(f"Progress: {progressbar.current}% - {round(progressbar.estimated_remaining_seconds)} seconds remaining")
+            print(f"Progress: {progressbar.current}% - {round(progressbar.estimated_remaining_seconds)} seconds remaining", flush=True)
 
         # sleep so that the exchange won't get angry at us
         if not already_exists:

--- a/jesse/modes/import_candles_mode/__init__.py
+++ b/jesse/modes/import_candles_mode/__init__.py
@@ -138,10 +138,11 @@ def run(
                             'message': msg,
                             'type': 'success'
                         })
+                        run(exchange, symbol, jh.timestamp_to_time(first_existing_timestamp)[:10])
+                        return
                     else:
                         print(msg)
-                    run(exchange, symbol, jh.timestamp_to_time(first_existing_timestamp)[:10], mode, running_via_dashboard, show_progressbar)
-                    return
+                        return run(exchange, symbol, jh.timestamp_to_time(first_existing_timestamp)[:10], running_via_dashboard=False, show_progressbar=show_progressbar)
 
             # fill absent candles (if there's any)
             candles = _fill_absent_candles(candles, temp_start_timestamp, temp_end_timestamp)

--- a/jesse/modes/import_candles_mode/__init__.py
+++ b/jesse/modes/import_candles_mode/__init__.py
@@ -138,8 +138,7 @@ def run(
                             'message': msg,
                             'type': 'success'
                         })
-                        run(exchange, symbol, jh.timestamp_to_time(first_existing_timestamp)[:10])
-                        return
+                        return run(exchange, symbol, jh.timestamp_to_time(first_existing_timestamp)[:10])
                     else:
                         print(msg)
                         return run(exchange, symbol, jh.timestamp_to_time(first_existing_timestamp)[:10], running_via_dashboard=False, show_progressbar=show_progressbar)


### PR DESCRIPTION
import_candles() when called via jesse.research exits early when the start_date of the candles is before the first available date. This is due to the "return" returning nothing and calling run() on a separate line instead of returning the result of run().

I have used the existing running_via_dashboard if statement to run the current version of the code, if not running_via_dashboard then instead the recursive run() is called, passed the relevant parameters, and then returned.

This results in the expected behavior of receiving the "Successfully imported candles for..." message regardless of whether the start_date that was passed to import_candles() via jesse.research was before the first available date or not.

N.B The "No candle exists in the market for..." message is not known to the user when they call import_candles(), They only ever receive the success message. Considering the return statements in run() are only returned when not using the dashboard, i.e. via research, a named tuple could be returned to return the "No candle exists in the market for..." if there is one, and the success message. Not a deal breaker but a nice to know for the user if they are logging the candle downloading. Currently the only way to know if that occurred is to compare the start_date that was passed to import_candles() and to look at the success message and see if the dates match.

![Capture](https://user-images.githubusercontent.com/36841939/188149421-2ee7494f-8194-40be-a774-c49c8e5bb330.PNG)

![Capture2](https://user-images.githubusercontent.com/36841939/188149252-50af9e2f-39fa-4c94-81ff-3c9293c421be.PNG)
