### PR TITLE
terminate() should be the final method called.

### DIFF
--- a/jesse/strategies/Strategy.py
+++ b/jesse/strategies/Strategy.py
@@ -801,9 +801,7 @@ class Strategy(ABC):
         """
         if not jh.should_execute_silently() or jh.is_debugging():
             logger.info(f"Terminating {self.symbol}...")
-
-        self.terminate()
-
+            
         self._detect_and_handle_entry_and_exit_modifications()
 
         # fake execution of market orders in backtest simulation
@@ -829,6 +827,8 @@ class Strategy(ABC):
         if len(self.entry_orders):
             self._execute_cancel()
             logger.info('Canceled open-position orders because we reached the end of the backtest session.')
+            
+        self.terminate()
 
     def terminate(self):
         pass


### PR DESCRIPTION
Currently terminate() is called before closing out the final backtest trades. The backtest is complete once all trades have been closed, metrics updated etc, not before. Even Jesse's documentation states the purpose of the function. "Examples of such a task would be to log a value or save a machine learning model.". Depending what values are saved they will probably be wrong because the final trades would alter them.

![Capture](https://user-images.githubusercontent.com/36841939/190207134-8bc3f3aa-63da-4818-a3d9-39e040b1c16e.PNG)

Imagine the most basic use of the terminate() function, for e.g. writing all trades to a log file. The current order of operation would mean there would be trades missing...