### PR TITLE
improve equity curve readability

### DIFF
--- a/jesse/services/charts.py
+++ b/jesse/services/charts.py
@@ -47,7 +47,11 @@ def portfolio_vs_asset_returns(study_name: str = None) -> str:
         plt.title(f'Portfolio Daily Return - {study_name}')
     else:
         plt.title('Portfolio Daily Return')
-    plt.plot(date_list, store.app.daily_balance)
+        
+    start_balance_arr = np.full(len(store.app.daily_balance), store.app.daily_balance[0])
+    plt.fill_between(date_list, store.app.daily_balance, start_balance_arr, where=start_balance_arr < store.app.daily_balance, color='green', alpha=0.5)
+    plt.fill_between(date_list, start_balance_arr, store.app.daily_balance, where=start_balance_arr > store.app.daily_balance, color='red', alpha=0.7)
+    plt.plot(date_list, store.app.daily_balance, linewidth='4')
 
     # price change%
     plt.subplot(2, 1, 2)


### PR DESCRIPTION
Saleh,
I collate Jesse's backtest / walk forward results into a spreadsheet, and exsting equity curve was very faint when downscaling to fit into a cell. I somewhat improved it to be more readable, hope it's useful for others.

Changes:
- equity curve linewidth = 4, 
- added green/red fills for above / underwater periods

Before:
https://www.dropbox.com/s/ibp2owkbo8fikem/93308f1d-cbf9-43bf-aede-bba35f830997.png?dl=0

After:
https://www.dropbox.com/s/pgjipxr5lvy16v3/3e278f87-6b8d-4f95-9d73-fe5dde6e3d5e.png?dl=0