### PR TITLE
decrease number of candles requested to reduce API weight usage

### DIFF
--- a/jesse/modes/import_candles_mode/drivers/Binance/BinanceMain.py
+++ b/jesse/modes/import_candles_mode/drivers/Binance/BinanceMain.py
@@ -14,7 +14,7 @@ class BinanceMain(CandleExchange):
     ) -> None:
         super().__init__(
             name=name,
-            count=1000,
+            count=499,
             rate_limit_per_second=2,
             backup_exchange_class=backup_exchange_class
         )


### PR DESCRIPTION
Binance API quota is 1200-2400 weights per minute. Currently each REST candle request costs 5 weights due to `limit=1000`. This results in higher than necessary API usage and potential overflow when trading many routes on the same IP. Reducing limit to 499 drops weight usage to 2 per request, effectively allowing 2.5x more candle queries without risk of getting banned. If I understand correctly, this should not affect live trading candle generation, as 499 candles should be sufficient for any reasonable timeframe.