### PR TITLE
do not escape markdown punctuation

### DIFF
--- a/jesse/services/notifier.py
+++ b/jesse/services/notifier.py
@@ -137,10 +137,10 @@ def _discord_errors(msg: str) -> None:
 def _format_msg(msg: str) -> str:
     # if "_" exists in the message, replace it with "\_"
     msg = msg.replace('_', '\_')
-    # if "*" exists in the message, replace it with "\*"
-    msg = msg.replace('*', '\*')
-    # if "[" exists in the message, replace it with "\["
-    msg = msg.replace('[', '\[')
-    # if "]" exists in the message, replace it with "\}"
-    msg = msg.replace(']', '\]')
+    # # if "*" exists in the message, replace it with "\*"
+    # msg = msg.replace('*', '\*')
+    # # if "[" exists in the message, replace it with "\["
+    # msg = msg.replace('[', '\[')
+    # # if "]" exists in the message, replace it with "\}"
+    # msg = msg.replace(']', '\]')
     return msg


### PR DESCRIPTION
Telegram messages are sent using `Markdown` parser, yet most of markdown punctation is escaped here. 
To make notifications more useful, I disabled escaping, which enabled correct rendering for the following notificatiobs: 

```python
    slf.log(f"{active}{slf.vars['bars']} {emoji}*{round(slf.position.pnl_percentage, 2)}%* [{slf.symbol}](https://www.binance.com/en/futures/{symbol}){slf.timeframe} *{order_kind}* dd: {round(slf.vars['drawdown'], 2)}%, ut: {round(slf.vars['uptick'], 2)}% {type(slf).__name__} {slf.port}: `{slf.note}`", send_notification=True)
```

Result:

![image](https://user-images.githubusercontent.com/4336560/229021507-78bbd638-8624-44ac-b9c1-d5161d3cb80b.png)
