### PR TITLE
fix percentage difference calculation math

### DIFF
--- a/jesse/services/broker.py
+++ b/jesse/services/broker.py
@@ -94,7 +94,7 @@ class Broker:
 
         # MARKET order
         # if the price difference is bellow 0.01% of the current price, then we submit a market order
-        if abs(price - current_price) < 0.0001:
+        if abs(1 - (price / current_price)) < 0.0001:
             return self.api.market_order(
                 self.exchange,
                 self.symbol,

--- a/jesse/strategies/Strategy.py
+++ b/jesse/strategies/Strategy.py
@@ -231,7 +231,7 @@ class Strategy(ABC):
 
         for o in self._buy:
             # MARKET order
-            if abs(o[1] - price_to_compare) < 0.0001:
+            if abs(1 - (o[1] / price_to_compare)) < 0.0001:
                 self.broker.buy_at_market(o[0])
             # STOP order
             elif o[1] > price_to_compare:
@@ -247,7 +247,7 @@ class Strategy(ABC):
 
         for o in self._sell:
             # MARKET order
-            if abs(o[1] - price_to_compare) < 0.0001:
+            if abs(1 - (o[1] / price_to_compare)) < 0.0001:
                 self.broker.sell_at_market(o[0])
             # STOP order
             elif o[1] < price_to_compare:


### PR DESCRIPTION
the math for calculation of percentage difference was wrong, resulting in MARKET orders instead of STOP/LIMIT for low-price asset pairs. 