### PR TITLE
fix price comparison for market order

### DIFF
--- a/jesse/services/broker.py
+++ b/jesse/services/broker.py
@@ -94,7 +94,7 @@ class Broker:
 
         # MARKET order
         # if the price difference is bellow 0.01% of the current price, then we submit a market order
-        if abs(price - current_price) < 0.0001:
+        if abs(price - current_price) < 0.0001 * current_price:
             return self.api.market_order(
                 self.exchange,
                 self.symbol,


### PR DESCRIPTION
The code is making a market order if the absolute difference between price and current_price is less than 0.01% of the current price. However, the current logic in the code is checking the absolute difference but not the percent difference. 
To fix it we need to multiply 0.0001 by the current_price.