### PR TITLE
Kelly criterion calculated wrong.

### DIFF
--- a/jesse/services/metrics.py
+++ b/jesse/services/metrics.py
@@ -94,6 +94,9 @@ def trades(trades_list: List[ClosedTrade], daily_balance: list, final: bool = Tr
     fee = df['fee'].sum()
     net_profit = df['PNL'].sum()
     net_profit_percentage = (net_profit / starting_balance) * 100
+    avg_win_percentage = df.loc[df['PNL'] > 0, 'PNL_percentage'].sum() / len(winning_trades)
+    avg_loss_percentage = -df.loc[df['PNL'] < 0, 'PNL_percentage'].sum() / len(losing_trades)
+
     average_win = winning_trades['PNL'].mean()
     average_loss = abs(losing_trades['PNL'].mean())
     ratio_avg_win_loss = average_win / average_loss
@@ -147,6 +150,8 @@ def trades(trades_list: List[ClosedTrade], daily_balance: list, final: bool = Tr
         'starting_balance': np.nan if np.isnan(starting_balance) else starting_balance,
         'finishing_balance': np.nan if np.isnan(current_balance) else current_balance,
         'win_rate': np.nan if np.isnan(win_rate) else win_rate,
+        'avg_win_percentage': np.nan if np.isnan(avg_win_percentage) else avg_win_percentage,
+        'avg_loss_percentage': np.nan if np.isnan(avg_loss_percentage) else avg_loss_percentage,
         'ratio_avg_win_loss': np.nan if np.isnan(ratio_avg_win_loss) else ratio_avg_win_loss,
         'longs_count': np.nan if np.isnan(longs_count) else longs_count,
         'longs_percentage': np.nan if np.isnan(longs_percentage) else longs_percentage,

--- a/jesse/utils.py
+++ b/jesse/utils.py
@@ -259,8 +259,8 @@ def signal_line(series: np.ndarray, period: int = 10, matype: int = 0) -> np.nda
     return ma(series, period=period, matype=matype, sequential=True)
 
 
-def kelly_criterion(win_rate: float, ratio_avg_win_loss: float) -> float:
-    return win_rate - ((1 - win_rate) / ratio_avg_win_loss)
+def kelly_criterion(win_rate: float, ratio_avg_win: float, ratio_avg_loss: float) -> float:
+    return win_rate/ratio_avg_loss - ((1 - win_rate) / ratio_avg_win)
 
 
 def prices_to_returns(price_series: np.ndarray) -> np.ndarray:


### PR DESCRIPTION
I wanted to implement kelly criterion in my strategy after seeing this video:
https://www.youtube.com/watch?v=_FuuYSM7yOo&ab_channel=MarcinAnforowicz

Happy to know that jesse support that and also has an example in the docs.
https://docs.jesse.trade/docs/strategies/example-strategies.html#getting-the-size-right

Unfortunate after several experiments and investigatation I found that something is off. The problem was in the method of `utils.kelly_criterion`

The results are completly different between these formulas to `utils.kelly_criterion` formula.


