### PR TITLE
Update requirements to 3.11.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 arrow==1.2.1
 blinker==1.4
 click==8.0.3
-matplotlib==3.8.3
+matplotlib==3.7.4
 mplfinance==0.12.8b6
 newtulipy==0.4.6
 numpy==1.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ click==8.0.3
 matplotlib==3.5.1
 mplfinance==0.12.8b6
 newtulipy==0.4.6
-numpy==1.26.4
+numpy==1.23.0
 numpy_groupies==0.9.14
 pandas==1.4.0
 peewee==3.14.8
@@ -15,7 +15,7 @@ PyWavelets==1.2.0
 quantstats==0.0.47
 requests==2.31.0
 scipy
-statsmodels==0.14.1
+statsmodels==0.14.0
 TA-Lib==0.4.28
 tabulate==0.8.9
 timeloop==1.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ numpy==1.23.0
 numpy_groupies==0.9.14
 pandas==1.4.0
 peewee==3.14.8
-psycopg2-binary==2.9.4
+psycopg2-binary==2.9.9
 pydash==6.0.0
 pytest==6.2.5
 PyWavelets==1.2.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 arrow==1.2.1
 blinker==1.4
 click==8.0.3
-matplotlib==3.5.1
+matplotlib==3.8.3
 mplfinance==0.12.8b6
 newtulipy==0.4.6
 numpy==1.23.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ click==8.0.3
 matplotlib==3.5.1
 mplfinance==0.12.8b6
 newtulipy==0.4.6
-numpy==1.23.0
+numpy==1.26.4
 numpy_groupies==0.9.14
 pandas==1.4.0
 peewee==3.14.8
@@ -15,7 +15,7 @@ PyWavelets==1.2.0
 quantstats==0.0.47
 requests==2.31.0
 scipy
-statsmodels==0.14.0
+statsmodels==0.14.1
 TA-Lib==0.4.28
 tabulate==0.8.9
 timeloop==1.0.2


### PR DESCRIPTION
I wanted to upgrade my python version from 3.9 to 3.11 and i was unable to install jesse  until i upgraded these packages. I  tried on 3.11.2 and 3.11.7 and on both of them the installation didnt work.

