### PR TITLE
Faster simulation

### DIFF
--- a/jesse/libs/dynamic_numpy_array/__init__.py
+++ b/jesse/libs/dynamic_numpy_array/__init__.py
@@ -19,7 +19,7 @@ class DynamicNumpyArray:
         self.drop_at = drop_at
 
     def __str__(self) -> str:
-        return str(self.array[:self.index + 1])
+        return str(self.array[: self.index + 1])
 
     def __len__(self) -> int:
         return self.index + 1
@@ -39,7 +39,9 @@ class DynamicNumpyArray:
 
             # validation
             if self.index == -1 or i > self.index or i < 0:
-                raise IndexError(f'list assignment index out of range. self.index={self.index}, i={i}')
+                raise IndexError(
+                    f"list assignment index out of range. self.index={self.index}, i={i}"
+                )
 
             return self.array[i]
 
@@ -62,7 +64,7 @@ class DynamicNumpyArray:
 
         # validation
         if i > self.index or i < 0:
-            raise IndexError('list assignment index out of range')
+            raise IndexError("list assignment index out of range")
 
         self.array[i] = item
 
@@ -89,17 +91,23 @@ class DynamicNumpyArray:
     def get_last_item(self):
         # validation
         if self.index == -1:
-            raise IndexError('list assignment index out of range. array is empty which means no past item exists')
+            raise IndexError(
+                "list assignment index out of range. array is empty which means no past item exists"
+            )
 
         return self.array[self.index]
 
     def get_past_item(self, past_index) -> np.ndarray:
         # validation
         if self.index == -1:
-            raise IndexError('list assignment index out of range. array is empty which means no past item exists')
+            raise IndexError(
+                "list assignment index out of range. array is empty which means no past item exists"
+            )
         # validation
         if (self.index - past_index) < 0:
-            raise IndexError(f'list assignment index out of range. Max allowed is self.index={self.index}, past_index={past_index}')
+            raise IndexError(
+                f"list assignment index out of range. Max allowed is self.index={self.index}, past_index={past_index}"
+            )
 
         return self.array[self.index - past_index]
 
@@ -112,8 +120,14 @@ class DynamicNumpyArray:
         self.index += len(items)
 
         # expand if the arr will be greater than the maximum
-        if self.index != 0 and (self.index + 1) > len(self.array):
-            new_bucket = np.zeros(self.shape)
+        if self.index != 0 and (self.index + 1) >= len(self.array):
+            # in case the shape is smaller than  len(items)
+            if isinstance(self.shape, int):
+                shape = max(self.shape, len(items))
+            else:
+                shape = list(self.shape)
+                shape[0] = max(len(items), shape[0])
+            new_bucket = np.zeros(shape)
             self.array = np.concatenate((self.array, new_bucket), axis=0)
 
         # drop N% of the beginning values to free memory

--- a/jesse/libs/dynamic_numpy_array/__init__.py
+++ b/jesse/libs/dynamic_numpy_array/__init__.py
@@ -44,6 +44,19 @@ class DynamicNumpyArray:
             return self.array[i]
 
     def __setitem__(self, i, item) -> None:
+        if isinstance(i, slice):
+            start = i.start
+            stop = i.stop
+            step = i.step
+            if start is not None and start < 0:
+                start = (self.index + 1) - abs(start)
+            if stop is None:
+                stop = start + len(item)
+            if stop < 0:
+                stop = (self.index + 1) - abs(stop)
+            self.array[slice(start, stop, step)] = item
+            return
+
         if i < 0:
             i = (self.index + 1) - abs(i)
 
@@ -94,3 +107,23 @@ class DynamicNumpyArray:
         self.index = -1
         self.array = np.zeros(self.shape)
         self.bucket_size = self.shape[0]
+
+    def append_multiple(self, items: np.ndarray) -> None:
+        self.index += len(items)
+
+        # expand if the arr will be greater than the maximum
+        if self.index != 0 and (self.index + 1) > len(self.array):
+            new_bucket = np.zeros(self.shape)
+            self.array = np.concatenate((self.array, new_bucket), axis=0)
+
+        # drop N% of the beginning values to free memory
+        if (
+            self.drop_at is not None
+            and self.index != 0
+            and (self.index + 1) % self.drop_at == 0
+        ):
+            shift_num = int(self.drop_at / 2)
+            self.index -= shift_num
+            self.array = np_shift(self.array, -shift_num)
+
+        self.array[self.index - len(items) + 1 : self.index + 1] = items

--- a/jesse/libs/dynamic_numpy_array/__init__.py
+++ b/jesse/libs/dynamic_numpy_array/__init__.py
@@ -19,7 +19,7 @@ class DynamicNumpyArray:
         self.drop_at = drop_at
 
     def __str__(self) -> str:
-        return str(self.array[: self.index + 1])
+        return str(self.array[:self.index + 1])
 
     def __len__(self) -> int:
         return self.index + 1
@@ -39,9 +39,7 @@ class DynamicNumpyArray:
 
             # validation
             if self.index == -1 or i > self.index or i < 0:
-                raise IndexError(
-                    f"list assignment index out of range. self.index={self.index}, i={i}"
-                )
+                raise IndexError(f'list assignment index out of range. self.index={self.index}, i={i}')
 
             return self.array[i]
 
@@ -64,7 +62,7 @@ class DynamicNumpyArray:
 
         # validation
         if i > self.index or i < 0:
-            raise IndexError("list assignment index out of range")
+            raise IndexError('list assignment index out of range')
 
         self.array[i] = item
 
@@ -91,23 +89,17 @@ class DynamicNumpyArray:
     def get_last_item(self):
         # validation
         if self.index == -1:
-            raise IndexError(
-                "list assignment index out of range. array is empty which means no past item exists"
-            )
+            raise IndexError('list assignment index out of range. array is empty which means no past item exists')
 
         return self.array[self.index]
 
     def get_past_item(self, past_index) -> np.ndarray:
         # validation
         if self.index == -1:
-            raise IndexError(
-                "list assignment index out of range. array is empty which means no past item exists"
-            )
+            raise IndexError('list assignment index out of range. array is empty which means no past item exists')
         # validation
         if (self.index - past_index) < 0:
-            raise IndexError(
-                f"list assignment index out of range. Max allowed is self.index={self.index}, past_index={past_index}"
-            )
+            raise IndexError(f'list assignment index out of range. Max allowed is self.index={self.index}, past_index={past_index}')
 
         return self.array[self.index - past_index]
 

--- a/jesse/modes/backtest_mode.py
+++ b/jesse/modes/backtest_mode.py
@@ -598,7 +598,7 @@ def _skip_simulator(
             exchange = candles[j]["exchange"]
             symbol = candles[j]["symbol"]
 
-            _simulate_price_change_effect__multiple_candles(
+            _simulate_price_change_effect_multiple_candles(
                 short_candles, exchange, symbol
             )
 
@@ -709,7 +709,7 @@ def _calculate_min_step():
     return np.gcd.reduce(consider_time_frames)
 
 
-def _simulate_price_change_effect__multiple_candles(
+def _simulate_price_change_effect_multiple_candles(
     short_timeframes_candles: np.ndarray, exchange: str, symbol: str
 ) -> None:
     real_candle = np.array(

--- a/jesse/modes/backtest_mode.py
+++ b/jesse/modes/backtest_mode.py
@@ -224,9 +224,11 @@ def load_candles(start_date_str: str, finish_date_str: str) -> Dict[str, Dict[st
     return candles
 
 
-def simulator(*args, **kwargs) -> dict:
+def simulator(*args, fast_simulation: bool = False, **kwargs) -> dict:
+    if fast_simulation:
+        return _skip_simulator(*args, **kwargs)
+
     return _step_simulator(*args, **kwargs)
-    # return _skip_simulator(*args, **kwargs)
 
 
 def _step_simulator(

--- a/jesse/modes/backtest_mode.py
+++ b/jesse/modes/backtest_mode.py
@@ -224,8 +224,8 @@ def load_candles(start_date_str: str, finish_date_str: str) -> Dict[str, Dict[st
     return candles
 
 
-def simulator(*args, fast_simulation: bool = False, **kwargs) -> dict:
-    if fast_simulation:
+def simulator(*args, fast_mode: bool = False, **kwargs) -> dict:
+    if fast_mode:
         return _skip_simulator(*args, **kwargs)
 
     return _step_simulator(*args, **kwargs)

--- a/jesse/research/backtest.py
+++ b/jesse/research/backtest.py
@@ -17,7 +17,7 @@ def backtest(
         generate_json: bool = False,
         generate_logs: bool = False,
         hyperparameters: dict = None,
-        fast_simulation: bool = True
+        fast_mode: bool = True
 ) -> dict:
     """
     An isolated backtest() function which is perfect for using in research, and AI training
@@ -66,7 +66,7 @@ def backtest(
         generate_equity_curve=generate_equity_curve,
         generate_hyperparameters=generate_hyperparameters,
         generate_logs=generate_logs,
-        fast_simulation=fast_simulation,
+        fast_mode=fast_mode,
     )
 
 
@@ -86,7 +86,7 @@ def _isolated_backtest(
         generate_equity_curve: bool = False,
         generate_hyperparameters: bool = False,
         generate_logs: bool = False,
-        fast_simulation: bool = True,
+        fast_mode: bool = True,
 ) -> dict:
     from jesse.services.validators import validate_routes
     from jesse.modes.backtest_mode import simulator
@@ -163,7 +163,7 @@ def _isolated_backtest(
         generate_equity_curve=generate_equity_curve,
         generate_hyperparameters=generate_hyperparameters,
         generate_logs=generate_logs,
-        fast_simulation=fast_simulation,
+        fast_mode=fast_mode,
     )
 
     result = {

--- a/jesse/research/backtest.py
+++ b/jesse/research/backtest.py
@@ -16,7 +16,8 @@ def backtest(
         generate_csv: bool = False,
         generate_json: bool = False,
         generate_logs: bool = False,
-        hyperparameters: dict = None
+        hyperparameters: dict = None,
+        fast_simulation: bool = True
 ) -> dict:
     """
     An isolated backtest() function which is perfect for using in research, and AI training
@@ -64,7 +65,8 @@ def backtest(
         generate_json=generate_json,
         generate_equity_curve=generate_equity_curve,
         generate_hyperparameters=generate_hyperparameters,
-        generate_logs=generate_logs
+        generate_logs=generate_logs,
+        fast_simulation=fast_simulation,
     )
 
 
@@ -83,7 +85,8 @@ def _isolated_backtest(
         generate_json: bool = False,
         generate_equity_curve: bool = False,
         generate_hyperparameters: bool = False,
-        generate_logs: bool = False
+        generate_logs: bool = False,
+        fast_simulation: bool = True,
 ) -> dict:
     from jesse.services.validators import validate_routes
     from jesse.modes.backtest_mode import simulator
@@ -159,7 +162,8 @@ def _isolated_backtest(
         generate_json=generate_json,
         generate_equity_curve=generate_equity_curve,
         generate_hyperparameters=generate_hyperparameters,
-        generate_logs=generate_logs
+        generate_logs=generate_logs,
+        fast_simulation=fast_simulation,
     )
 
     result = {

--- a/jesse/store/state_candles.py
+++ b/jesse/store/state_candles.py
@@ -406,7 +406,6 @@ class CandlesState:
         exchange: str,
         symbol: str,
     ) -> None:
-        # assuming the functionality is only for '1m' candles for now
         if jh.is_collecting_data():
             raise NotImplemented("Collecting data is deactivated at the moment")
             # make sure it's a complete (and not a forming) candle
@@ -417,7 +416,7 @@ class CandlesState:
             # For now it's only implemented for backtesting
             return
 
-        arr: DynamicNumpyArray = self.get_storage(exchange, symbol, timeframe)
+        arr: DynamicNumpyArray = self.get_storage(exchange, symbol, '1m')
 
         # initial
         if len(arr) == 0:

--- a/jesse/store/state_candles.py
+++ b/jesse/store/state_candles.py
@@ -433,15 +433,6 @@ class CandlesState:
             )
             arr[-override_candles:] = candles
 
-        # yakir: Couldn't reach to this, couldn't figure what is it needed for.
-        # allow updating of the previous candle.
-        # elif candle[0] < arr[-1][0]:
-        #     # loop through the last 20 items in arr to find it. If so, update it.
-        #     for i in range(max(20, len(arr) - 1)):
-        #         if arr[-i][0] == candle[0]:
-        #             arr[-i] = candle
-        #             break
+        # Otherwise,it's true and error.
         else:
-            logger.info(
-                f"Could not find the candle with timestamp {jh.timestamp_to_time(candle[0])} in the storage. Last candle's timestamp: {jh.timestamp_to_time(arr[-1])}. timeframe: {timeframe}, exchange: {exchange}, symbol: {symbol}"
-            )
+            raise IndexError(f"Could not find the candle with timestamp {jh.timestamp_to_time(candles[0, 0])} in the storage. Last candle's timestamp: {jh.timestamp_to_time(arr[-1])}. exchange: {exchange}, symbol: {symbol}")

--- a/jesse/store/state_candles.py
+++ b/jesse/store/state_candles.py
@@ -406,15 +406,8 @@ class CandlesState:
         exchange: str,
         symbol: str,
     ) -> None:
-        if jh.is_collecting_data():
-            raise NotImplemented("Collecting data is deactivated at the moment")
-            # make sure it's a complete (and not a forming) candle
-            # if jh.now_to_timestamp() >= (candle[0] + 60000):
-            #     store_candle_into_db(exchange, symbol, candle)
-            # return
-        if jh.is_live():
-            # For now it's only implemented for backtesting
-            return
+        if not jh.is_backtesting():
+            raise Exception('add_multiple_1m_candles() is for backtesting only')
 
         arr: DynamicNumpyArray = self.get_storage(exchange, symbol, '1m')
 


### PR DESCRIPTION
Now that I return to jesse, I want to try again this PR that makes jesse run faster by simply skip unused candles.
https://medium.com/@yakir4123/this-is-how-i-accelerated-jesse-a-python-framework-to-run-16-times-faster-part-i-4fce9c6ecef7
https://medium.com/@yakir4123/this-is-how-i-accelerated-jesse-a-python-framework-to-run-16-times-faster-part-ii-ec3a718095b3

I've tested it several times on different strategies.
Here is an example of timing the regular jesse algorithm for 2 years a strategy of route of 1h:

![image](https://github.com/jesse-ai/jesse/assets/38066978/45b1cd5b-c25c-41b6-a017-c81947622598)


and with my algorithm:
![image](https://github.com/jesse-ai/jesse/assets/38066978/b4b0f60a-9b82-44f8-b55b-f11d98c1643e)

* All the testes passed, the only thing that might be a problem that still I need to check is how well it works with several routes.
I think there may be a challange in there but that already can be used for optimization process where there is 1 route.


