### PR TITLE
Better estimation on candle import

### DIFF
--- a/jesse/services/progressbar.py
+++ b/jesse/services/progressbar.py
@@ -4,9 +4,11 @@ from jesse.libs import DynamicNumpyArray
 
 
 class Progressbar:
-    def __init__(self, length: int, step=1):
+    def __init__(self, length: int, step=1, completed: int = 0):
         self.length = length
         self.index = 0
+        self.completed = completed
+
 
         # validation
         if self.length <= self.index:
@@ -40,7 +42,7 @@ class Progressbar:
     def remaining_index(self):
         if self.is_finished:
             return 0
-        return self.length - self.index
+        return max((self.length - self.index - self.completed), 0)
 
     @property
     def estimated_remaining_seconds(self):


### PR DESCRIPTION
Lets say you already have a year worth of data, but forgot about the warmup_candles. Or you want to test larger time frames and need even more candles now. This will screw up the estimated time for the import.

This change allows an additional completed parameter for the Progressbar and uses that while importing candles. This way the estimated_remaining_seconds will take into account that most of the work might be done already.