### PR TITLE
Make app host configurable

### DIFF
--- a/jesse/__init__.py
+++ b/jesse/__init__.py
@@ -230,9 +230,14 @@ def run() -> None:
     else:
         port = 9000
 
+    if 'APP_HOST' in ENV_VALUES:
+        host = ENV_VALUES['APP_HOST']
+    else:
+        host = "0.0.0.0"
+
     # run the main application
     process_manager.flush()
-    uvicorn.run(fastapi_app, host="0.0.0.0", port=port, log_level="info")
+    uvicorn.run(fastapi_app, host=host, port=port, log_level="info")
 
 
 @fastapi_app.post('/general-info')


### PR DESCRIPTION
**What:** I've added the `APP_HOST` environment variable to make the host with which we [bind the uvicorn socket](https://www.uvicorn.org/settings/#socket-binding)  configurable.

**Why:** By default Jesse binds to `0.0.0.0:9000`, we can change the port by setting the `APP_PORT` to something different, but we cannot do that with the host. Using host `0.0.0.0` allows incoming traffic from any host to port `9000`. This has some undesirable side effects. 

A concrete example: Deploying Jesse with Docker in a DigitalOcean droplet, using Jesse's default socket, would expose the Jesse instance to the internet via the droplet's public IP on port 9000. Among other things, it makes the instance vulnerable to bruteforce attacks, if the attack suceeds, it would expose sensible data from the user. Also it would make the instance vulnerable to whatever vulnerability Uvicorn might have. 

Having a configurable host makes possible to set up and run Jesse behind a more robust Proxy, like Nginx or even Cloudflare. Another option is to have Jesse bound to `localhost:9000` (the port can be any port, of course) and then tunnel  via ssh to your local machine to access the app: `ssh -L 9191:localhost:9000 root@the.ip.of.my.server` (this what I do because is cheaper than Cloudflare)

![image](https://github.com/user-attachments/assets/8fc781dc-47d4-4c61-8a3d-aab192872711)

**How:** I've added the `APP_HOST` environment variable and set it to the default we've been using `0.0.0.0`