### PR TITLE
Crypto.com exchange added for backtesting

### DIFF
--- a/jesse/enums/__init__.py
+++ b/jesse/enums/__init__.py
@@ -80,6 +80,8 @@ class exchanges:
     APEX_PRO_PERPETUAL = 'Apex Pro Perpetual'
     GATE_USDT_PERPETUAL = 'Gate USDT Perpetual'
     GATE_SPOT = 'Gate Spot'
+    CRYPTO_COM_EXCHANGE_SPOT = 'CryptoDotCom Exchange Spot'
+    CRYPTO_COM_EXCHANGE_PERPETUAL_FUTURES = 'CryptoDotCom Exchange Perpetual Futures'
 
 
 class migration_actions:

--- a/jesse/info.py
+++ b/jesse/info.py
@@ -21,6 +21,9 @@ APEX_PRO_TIMEFRAMES = [timeframes.MINUTE_1, timeframes.MINUTE_5, timeframes.MINU
                        timeframes.MINUTE_30, timeframes.HOUR_1, timeframes.HOUR_4, timeframes.DAY_1]
 GATE_TIMEFRAMES = [timeframes.MINUTE_1, timeframes.MINUTE_5, timeframes.MINUTE_15,
                    timeframes.MINUTE_30, timeframes.HOUR_1, timeframes.HOUR_2, timeframes.HOUR_4, timeframes.HOUR_6, timeframes.HOUR_8, timeframes.HOUR_12, timeframes.DAY_1, timeframes.WEEK_1]
+CRYPTO_COM_EXCHANGE_TIMEFRAMES = [timeframes.MINUTE_1, timeframes.MINUTE_5, timeframes.MINUTE_15,
+                   timeframes.MINUTE_30, timeframes.HOUR_1, timeframes.HOUR_2, timeframes.HOUR_4, timeframes.HOUR_12, timeframes.DAY_1, timeframes.WEEK_1]
+
 
 exchange_info = {
     # BYBIT_USDT_PERPETUAL
@@ -361,6 +364,34 @@ exchange_info = {
         'modes': {
             'backtesting': False,
             'live_trading': True,
+        },
+        'required_live_plan': 'free'
+    },
+
+    exchanges_enums.CRYPTO_COM_EXCHANGE_SPOT: {
+        'name': exchanges_enums.CRYPTO_COM_EXCHANGE_SPOT,
+        'url': 'https://crypto.com/exchange/trade/BTC_USD',
+        'fee': 0.00075,
+        'type': 'spot',
+        'supported_leverage_modes': ['cross'],
+        'supported_timeframes': CRYPTO_COM_EXCHANGE_TIMEFRAMES,
+        'modes': {
+            'backtesting': True,
+            'live_trading': False,
+        },
+        'required_live_plan': 'free'
+    },
+
+    exchanges_enums.CRYPTO_COM_EXCHANGE_PERPETUAL_FUTURES: {
+        'name': exchanges_enums.CRYPTO_COM_EXCHANGE_PERPETUAL_FUTURES,
+        'url': 'https://crypto.com/exchange/trade/BTC_USD',
+        'fee': 0.00075,
+        'type': 'futures',
+        'supported_leverage_modes': ['cross'],
+        'supported_timeframes': CRYPTO_COM_EXCHANGE_TIMEFRAMES,
+        'modes': {
+            'backtesting': True,
+            'live_trading': False,
         },
         'required_live_plan': 'free'
     },

--- a/jesse/modes/import_candles_mode/drivers/CryptoCom/CryptoComExchangePerpetualFutures.py
+++ b/jesse/modes/import_candles_mode/drivers/CryptoCom/CryptoComExchangePerpetualFutures.py
@@ -1,0 +1,19 @@
+from .CryptoComMain import CryptoComMain
+from jesse.enums import exchanges
+import jesse.helpers as jh
+
+
+class CryptoComExchangePerpetualFutures(CryptoComMain):
+    def __init__(self) -> None:
+        from .CryptoComExchangeSpot import CryptoComExchangeSpot
+
+        super().__init__(
+            name=exchanges.CRYPTO_COM_EXCHANGE_PERPETUAL_FUTURES,
+            backup_exchange_class=None,
+            instrument_type = 'PERPETUAL_SWAP'
+        )
+
+    def _get_mapped_symbol_name(self, dashy_symbol):
+        return f"{jh.dashless_symbol(dashy_symbol)}-PERP"
+
+

--- a/jesse/modes/import_candles_mode/drivers/CryptoCom/CryptoComExchangeSpot.py
+++ b/jesse/modes/import_candles_mode/drivers/CryptoCom/CryptoComExchangeSpot.py
@@ -1,0 +1,15 @@
+from .CryptoComMain import CryptoComMain
+from jesse.enums import exchanges
+import jesse.helpers as jh
+
+
+class CryptoComExchangeSpot(CryptoComMain):
+    def __init__(self) -> None:
+        super().__init__(
+            name=exchanges.CRYPTO_COM_EXCHANGE_SPOT,
+            backup_exchange_class=None,
+            instrument_type='CCY_PAIR'
+        )
+
+    def _get_mapped_symbol_name(self, dashy_symbol):
+        return jh.dashy_to_underline(dashy_symbol)

--- a/jesse/modes/import_candles_mode/drivers/CryptoCom/CryptoComMain.py
+++ b/jesse/modes/import_candles_mode/drivers/CryptoCom/CryptoComMain.py
@@ -1,0 +1,99 @@
+from abc import abstractmethod
+from typing import Union
+import requests
+import jesse.helpers as jh
+from jesse.modes.import_candles_mode.drivers.interface import CandleExchange
+from .crypto_com_utils import timeframe_to_interval
+
+
+class CryptoComMain(CandleExchange):
+    def __init__(
+            self,
+            name: str,
+            backup_exchange_class,
+            instrument_type: str = ''
+    ) -> None:
+        super().__init__(
+            name=name,
+            count=300,
+            rate_limit_per_second=100,
+            backup_exchange_class=backup_exchange_class
+        )
+
+        self.endpoint = 'https://api.crypto.com'
+        self.instrument_type = instrument_type
+
+    def get_starting_time(self, symbol: str) -> int:
+        mapped_symbol = self._get_mapped_symbol_name(symbol)
+
+        payload = {
+            'timeframe': '1d',
+            'instrument_name': mapped_symbol,
+            'count': 1500,
+        }
+
+        response = requests.get(self.endpoint + self._prefix_address + 'get-candlestick', params=payload)
+
+        self.validate_response(response)
+
+        data = response.json()['result']['data']
+
+        # since the first timestamp doesn't include all the 1m
+        # candles, let's start since the second day then
+        first_timestamp = int(data[0]['t'])
+        return first_timestamp + 60_000 * 1440
+
+    def fetch(self, symbol: str, start_timestamp: int, timeframe: str = '1m') -> Union[list, None]:
+        end_timestamp = start_timestamp + (self.count - 1) * 60000 * jh.timeframe_to_one_minutes(timeframe)
+        interval = timeframe_to_interval(timeframe)
+        mapped_symbol = self._get_mapped_symbol_name(symbol)
+
+        payload = {
+            'timeframe': interval,
+            'instrument_name': mapped_symbol,
+            'start_ts': int(start_timestamp),
+            'end_ts': int(end_timestamp),
+            'count': self.count,
+        }
+
+        response = requests.get(self.endpoint + self._prefix_address + 'get-candlestick', params=payload)
+
+        self.validate_response(response)
+
+        data = response.json()['result']['data']
+        return [{
+            'id': jh.generate_unique_id(),
+            'exchange': self.name,
+            'symbol': symbol,
+            'timeframe': timeframe,
+            'timestamp': int(d['t']),
+            'open': float(d['o']),
+            'close': float(d['c']),
+            'high': float(d['h']),
+            'low': float(d['l']),
+            'volume': float(d['v'])
+        } for d in data]
+
+    def get_available_symbols(self) -> list:
+        response = requests.get(self.endpoint + self._prefix_address + 'get-instruments')
+
+        self.validate_response(response)
+        data = response.json()['result']['data']
+
+        return [self._dashy_symbol(d['base_ccy'], d['quote_ccy']) for d in data if self._filter_by_inst_type(d)]
+
+    @property
+    def _prefix_address(self):
+        return '/exchange/v1/public/'
+
+    def _filter_by_inst_type(self, item):
+        if not self.instrument_type:
+            return True
+        return item['inst_type'] == self.instrument_type
+
+    def _dashy_symbol(self, base, quote):
+        return f"{base}-{quote}"
+
+    @abstractmethod
+    def _get_mapped_symbol_name(self, dashy_symbol):
+        pass

--- a/jesse/modes/import_candles_mode/drivers/CryptoCom/crypto_com_utils.py
+++ b/jesse/modes/import_candles_mode/drivers/CryptoCom/crypto_com_utils.py
@@ -1,0 +1,66 @@
+from jesse.enums import timeframes
+
+
+def timeframe_to_interval(timeframe: str) -> str:
+    # 1m
+    # 5m
+    # 15m
+    # 30m
+    # 1h
+    # 2h
+    # 4h
+    # 12h
+    # 1d
+    # 1w
+    # 1M
+    if timeframe == timeframes.MINUTE_1:
+        return '1m'
+    elif timeframe == timeframes.MINUTE_5:
+        return '5m'
+    elif timeframe == timeframes.MINUTE_15:
+        return '15m'
+    elif timeframe == timeframes.MINUTE_30:
+        return '30m'
+    elif timeframe == timeframes.HOUR_1:
+        return '1h'
+    elif timeframe == timeframes.HOUR_2:
+        return '2h'
+    elif timeframe == timeframes.HOUR_4:
+        return '4h'
+    elif timeframe == timeframes.HOUR_12:
+        return '12h'
+    elif timeframe == timeframes.DAY_1:
+        return '1d'
+    elif timeframe == timeframes.WEEK_1:
+        return '7D'
+    elif timeframe == timeframes.MONTH_1:
+        return '1M'
+    else:
+        raise ValueError('Invalid timeframe: {}'.format(timeframe))
+
+
+def interval_to_timeframe(interval: str) -> str:
+    if interval == '1m':
+        return timeframes.MINUTE_1
+    elif interval == '5m':
+        return timeframes.MINUTE_5
+    elif interval == '15m':
+        return timeframes.MINUTE_15
+    elif interval == '30m':
+        return timeframes.MINUTE_30
+    elif interval == '1h':
+        return timeframes.HOUR_1
+    elif interval == '2h':
+        return timeframes.HOUR_2
+    elif interval == '4h':
+        return timeframes.HOUR_4
+    elif interval == '12h':
+        return timeframes.HOUR_12
+    elif interval == '1d':
+        return timeframes.DAY_1
+    elif interval == '7D':
+        return timeframes.WEEK_1
+    elif interval == '1M':
+        return timeframes.MONTH_1
+    else:
+        raise ValueError('Invalid interval: {}'.format(interval))

--- a/jesse/modes/import_candles_mode/drivers/__init__.py
+++ b/jesse/modes/import_candles_mode/drivers/__init__.py
@@ -22,6 +22,8 @@ from jesse.modes.import_candles_mode.drivers.Apex.ApexProPerpetualTestnet import
 from jesse.modes.import_candles_mode.drivers.Apex.ApexProPerpetual import ApexProPerpetual
 from jesse.modes.import_candles_mode.drivers.Gate.GateUSDTPerpetual import GateUSDTPerpetual
 from jesse.modes.import_candles_mode.drivers.Gate.GateSpot import GateSpot
+from jesse.modes.import_candles_mode.drivers.CryptoCom.CryptoComExchangeSpot import CryptoComExchangeSpot
+from jesse.modes.import_candles_mode.drivers.CryptoCom.CryptoComExchangePerpetualFutures import CryptoComExchangePerpetualFutures
 
 
 drivers = {
@@ -41,6 +43,7 @@ drivers = {
     exchanges.APEX_PRO_PERPETUAL: ApexProPerpetual,
     exchanges.GATE_USDT_PERPETUAL: GateUSDTPerpetual,
     exchanges.GATE_SPOT: GateSpot,
+    exchanges.CRYPTO_COM_EXCHANGE_PERPETUAL_FUTURES: CryptoComExchangePerpetualFutures,
 
     # Spot
     exchanges.FTX_SPOT: FTXSpot,
@@ -49,6 +52,7 @@ drivers = {
     exchanges.BINANCE_US_SPOT: BinanceUSSpot,
     exchanges.BYBIT_SPOT_TESTNET: BybitSpotTestnet,
     exchanges.BYBIT_SPOT: BybitSpot,
+    exchanges.CRYPTO_COM_EXCHANGE_SPOT: CryptoComExchangeSpot,
 
     # DEX
     exchanges.DYDX_PERPETUAL: DydxPerpetual,

--- a/tests/exchange_tests/crypto-dot-com/test_crypto_com_exchange_perpetual_futures.py
+++ b/tests/exchange_tests/crypto-dot-com/test_crypto_com_exchange_perpetual_futures.py
@@ -1,0 +1,22 @@
+import pytest
+
+from jesse.enums import exchanges
+from jesse.modes.import_candles_mode.drivers.CryptoCom.CryptoComExchangePerpetualFutures import CryptoComExchangePerpetualFutures
+
+class TestCryptoComExchangePerpetualFutures:
+
+    @pytest.fixture
+    def crypto_com_exchange_perpetual_futures(self):
+        class CryptoComExchangePerpetualFuturesTest(CryptoComExchangePerpetualFutures):
+            def __init__(self) -> None:
+                    super().__init__()
+
+        return CryptoComExchangePerpetualFuturesTest()
+
+    def test_init_params(self, crypto_com_exchange_perpetual_futures):
+        assert crypto_com_exchange_perpetual_futures.name == exchanges.CRYPTO_COM_EXCHANGE_PERPETUAL_FUTURES
+        assert crypto_com_exchange_perpetual_futures.instrument_type == 'PERPETUAL_SWAP'
+        assert crypto_com_exchange_perpetual_futures._backup_exchange_class == None
+
+    def test__get_mapped_symbol_name(self, crypto_com_exchange_perpetual_futures):
+        assert crypto_com_exchange_perpetual_futures._get_mapped_symbol_name('BTC-USD') == 'BTCUSD-PERP'

--- a/tests/exchange_tests/crypto-dot-com/test_crypto_com_exchange_spot.py
+++ b/tests/exchange_tests/crypto-dot-com/test_crypto_com_exchange_spot.py
@@ -1,0 +1,22 @@
+import pytest
+
+from jesse.enums import exchanges
+from jesse.modes.import_candles_mode.drivers.CryptoCom.CryptoComExchangeSpot import CryptoComExchangeSpot
+
+class TestCryptoComExchangeSpot:
+
+    @pytest.fixture
+    def crypto_com_exchange_spot(self):
+        class CryptoComExchangeSpotTest(CryptoComExchangeSpot):
+            def __init__(self) -> None:
+                    super().__init__()
+
+        return CryptoComExchangeSpotTest()
+
+    def test_init_params(self, crypto_com_exchange_spot):
+        assert crypto_com_exchange_spot.name == exchanges.CRYPTO_COM_EXCHANGE_SPOT
+        assert crypto_com_exchange_spot.instrument_type == 'CCY_PAIR'
+        assert crypto_com_exchange_spot._backup_exchange_class == None
+
+    def test__get_mapped_symbol_name(self, crypto_com_exchange_spot):
+        assert crypto_com_exchange_spot._get_mapped_symbol_name('BTC-USD') == 'BTC_USD'

--- a/tests/exchange_tests/crypto-dot-com/test_crypto_com_main.py
+++ b/tests/exchange_tests/crypto-dot-com/test_crypto_com_main.py
@@ -1,0 +1,94 @@
+import pytest
+
+from unittest.mock import patch, MagicMock
+from jesse.modes.import_candles_mode.drivers.CryptoCom.CryptoComMain import CryptoComMain
+
+class TestCryptoComMain:
+    @pytest.fixture
+    def crypto_com_main(self):
+        class CryptoComMainTest(CryptoComMain):
+            def _get_mapped_symbol_name(self, dashy_symbol):
+                return dashy_symbol.replace('-', '_')
+
+        return CryptoComMainTest(name="crypto_com", backup_exchange_class=None)
+
+    @patch('requests.get')
+    def test_get_starting_time(self, mock_get, crypto_com_main):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'result': {
+                'data': [{'t': 1609459200000}]  # 2021-01-01 00:00:00 UTC
+            }
+        }
+        mock_get.return_value = mock_response
+
+        result = crypto_com_main.get_starting_time('BTC-USDT')
+
+        assert result == 1609545600000  # 2021-01-02 00:00:00 UTC
+        mock_get.assert_called_once_with(
+            'https://api.crypto.com/exchange/v1/public/get-candlestick',
+            params={
+                'timeframe': '1d',
+                'instrument_name': 'BTC_USDT',
+                'count': 1500,
+            }
+        )
+
+    @patch('requests.get')
+    def test_fetch(self, mock_get, crypto_com_main):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'result': {
+                'data': [
+                    {'t': 1609459200000, 'o': '29000', 'c': '29100', 'h': '29200', 'l': '28900', 'v': '100'},
+                    {'t': 1609459260000, 'o': '29100', 'c': '29150', 'h': '29200', 'l': '29050', 'v': '50'},
+                ]
+            }
+        }
+        mock_get.return_value = mock_response
+
+        result = crypto_com_main.fetch('BTC-USDT', 1609459200000, '1m')
+
+        assert len(result) == 2
+        assert result[0]['timestamp'] == 1609459200000
+        assert result[0]['open'] == 29000.0
+        assert result[1]['close'] == 29150.0
+        mock_get.assert_called_once()
+
+    @patch('requests.get')
+    def test_get_available_symbols(self, mock_get, crypto_com_main):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = {
+            'result': {
+                'data': [
+                    {'base_ccy': 'BTC', 'quote_ccy': 'USDT', 'inst_type': 'CCY_PAIR'},
+                    {'base_ccy': 'ETH', 'quote_ccy': 'USDT', 'inst_type': 'PERPETUAL_SWAP'},
+                ]
+            }
+        }
+        mock_get.return_value = mock_response
+
+        result = crypto_com_main.get_available_symbols()
+
+        assert result == ['BTC-USDT', 'ETH-USDT']
+        mock_get.assert_called_once_with('https://api.crypto.com/exchange/v1/public/get-instruments')
+
+    def test_filter_by_inst_type(self, crypto_com_main):
+        item_spot = {'inst_type': 'SPOT'}
+        item_future = {'inst_type': 'FUTURE'}
+
+        assert crypto_com_main._filter_by_inst_type(item_spot) == True
+        assert crypto_com_main._filter_by_inst_type(item_future) == True
+
+        crypto_com_main.instrument_type = 'SPOT'
+        assert crypto_com_main._filter_by_inst_type(item_spot) == True
+        assert crypto_com_main._filter_by_inst_type(item_future) == False
+
+    def test_dashy_symbol(self, crypto_com_main):
+        assert crypto_com_main._dashy_symbol('BTC', 'USDT') == 'BTC-USDT'
+
+    def test_prefix_address(self, crypto_com_main):
+        assert crypto_com_main._prefix_address == '/exchange/v1/public/'


### PR DESCRIPTION
#### Summary
This PR adds support for **Crypto.com Spot** and **Perpetual Futures** exchanges, allowing backtesting and candle imports for both. The new options are integrated into the existing Candle Import and Backtesting interfaces.
I needed the exchange for my own backtesting purposes and thought it would be useful to others too.

#### Changes
- Added new classes to handle API access for both **Crypto.com Spot** and **Perpetual Futures**.
- Updated the necessary config and enums to ensure these new exchanges show up as selectable options, without changing the overall behavior of the application.

#### Testing
- Wrote `pytest`s to cover the new classes in `import_candles_mode`.

#### Notes
- I added entries for Crypto.com Exchange in `info.py` *exchange_info*.  The `live_trading` option is set to `False` since I haven't implemented that part, though it would be great to have it. :)
- Regarding the fee attribute, since Crypto.com has a progressive fee structure with different maker/taker rates, I opted to use the highest fee. This way, backtesting results will err on the side of caution (better to show worse performance than better-than-real).