### PR TITLE
handle UnicodeDecodeError

### DIFF
--- a/jesse/services/cache.py
+++ b/jesse/services/cache.py
@@ -21,7 +21,7 @@ class Cache:
                 with open(f"{self.path}cache_database.pickle", 'rb') as f:
                     try:
                         self.db = pickle.load(f)
-                    except (EOFError, pickle.UnpicklingError):
+                    except (EOFError, pickle.UnpicklingError, UnicodeDecodeError):
                         # File got broken
                         self.db = {}
             # if not, create a dict object. We'll create the file when using set_value()


### PR DESCRIPTION
Today out of the blue all my instances failed to restart with the following error:

```python
      '  File "/home/ubuntu/jesse-bot/lib/python3.11/site-packages/jesse/services/cache.py", line 95, in <module>\n' +
      '    cache = Cache("storage/temp/")\n' +
      '            ^^^^^^^^^^^^^^^^^^^^^^\n' +
      '  File "/home/ubuntu/jesse-bot/lib/python3.11/site-packages/jesse/services/cache.py", line 23, in __init__\n' +
      '    self.db = pickle.load(f)\n' +
      '              ^^^^^^^^^^^^^^\n' +
      "UnicodeDecodeError: 'utf-8' codec can't decode byte 0x95 in position 67: invalid start byte\n" +
      '\n' +
```

Adding `UnicodeDecodeError` to handled exceptions helped.