### PR TITLE
Fix metrics

### DIFF
--- a/jesse/factories/__init__.py
+++ b/jesse/factories/__init__.py
@@ -2,3 +2,4 @@ from .candle_factory import fake_candle
 from .candle_factory import range_candles
 from .candle_factory import candles_from_close_prices
 from .order_factory import fake_order
+from .candle_factory import smooth_sine_wave_candles

--- a/jesse/factories/candle_factory.py
+++ b/jesse/factories/candle_factory.py
@@ -54,6 +54,35 @@ def candles_from_close_prices(prices: Union[list, range]) -> np.ndarray:
     return np.array(arr)
 
 
+def smooth_sine_wave_candles(length: int, min_price: float, max_price: float, waves: int = 5, timestamp_increment: int = 60000):
+
+    # Create sine wave closing prices
+    x = np.linspace(0, 2 * np.pi * waves, length)
+    y = (np.sin(x) + 1) / 2  # normalize sine wave to [0,1]
+    scaled = y * (max_price - min_price) + min_price
+
+    fake_candle(reset=True)
+    global first_timestamp
+    arr = []
+    prev_p = np.nan
+    for p in scaled:
+        if np.isnan(prev_p):
+            prev_p = p
+
+        first_timestamp += timestamp_increment
+        open_p = prev_p
+        close_p = p
+        high_p = max(open_p, close_p)
+        low_p = min(open_p, close_p)
+        vol = randint(0, 200)
+
+        arr.append([first_timestamp, open_p, close_p, high_p, low_p, vol])
+        prev_p = p
+
+    return np.array(arr)
+
+
+
 def fake_candle(attributes: dict = None, reset: bool = False) -> np.ndarray:
     global first_timestamp
     global open_price

--- a/jesse/factories/candle_factory.py
+++ b/jesse/factories/candle_factory.py
@@ -54,10 +54,10 @@ def candles_from_close_prices(prices: Union[list, range]) -> np.ndarray:
     return np.array(arr)
 
 
-def smooth_sine_wave_candles(length: int, min_price: float, max_price: float, waves: int = 5, timestamp_increment: int = 60000):
+def smooth_sine_wave_candles(length: int, min_price: float, max_price: float, n_waves: int = 5, timestamp_increment: int = 60000):
 
     # Create sine wave closing prices
-    x = np.linspace(0, 2 * np.pi * waves, length)
+    x = np.linspace(0, 2 * np.pi * n_waves, length)
     y = (np.sin(x) + 1) / 2  # normalize sine wave to [0,1]
     scaled = y * (max_price - min_price) + min_price
 

--- a/jesse/factories/candle_factory.py
+++ b/jesse/factories/candle_factory.py
@@ -79,6 +79,11 @@ def smooth_sine_wave_candles(length: int, min_price: float, max_price: float, wa
         arr.append([first_timestamp, open_p, close_p, high_p, low_p, vol])
         prev_p = p
 
+    arr_np = np.array(arr)
+    price_columns = arr_np[:, 1:5]
+    # Assert all prices are within bounds
+    assert ((price_columns >= min_price) & (price_columns <= max_price)).all(), "Price values out of bounds"
+
     return np.array(arr)
 
 

--- a/jesse/modes/backtest_mode.py
+++ b/jesse/modes/backtest_mode.py
@@ -511,6 +511,8 @@ def _step_simulator(
 
         if i != 0 and i % 1440 == 0:
             save_daily_portfolio_balance()
+        elif i == length - 1:
+            save_daily_portfolio_balance()
 
     _finish_progress_bar(progressbar, run_silently)
 
@@ -523,9 +525,6 @@ def _step_simulator(
     for r in router.routes:
         r.strategy._terminate()
         _execute_market_orders()
-
-    # now that backtest simulation is finished, add finishing balance
-    save_daily_portfolio_balance()
 
     # set the ending time for the backtest session
     store.app.ending_time = store.app.time + 60_000
@@ -825,7 +824,10 @@ def _skip_simulator(
         # now check to see if there's any MARKET orders waiting to be executed
         _execute_market_orders()
 
+        last_i = (length - 1) // candles_step * candles_step
         if i != 0 and i % 1440 == 0:
+            save_daily_portfolio_balance()
+        elif i == last_i:
             save_daily_portfolio_balance()
 
     _finish_progress_bar(progressbar, run_silently)
@@ -839,9 +841,6 @@ def _skip_simulator(
     for r in router.routes:
         r.strategy._terminate()
         _execute_market_orders()
-
-    # now that backtest simulation is finished, add finishing balance
-    save_daily_portfolio_balance()
 
     # set the ending time for the backtest session
     store.app.ending_time = store.app.time + 60_000

--- a/jesse/strategies/TestMetrics2/__init__.py
+++ b/jesse/strategies/TestMetrics2/__init__.py
@@ -1,0 +1,22 @@
+from jesse.strategies import Strategy
+
+
+class TestMetrics2(Strategy):
+    def should_long(self) -> bool:
+        return self.price < 15
+
+    def should_short(self) -> bool:
+        return self.price > 15
+
+    def go_long(self):
+        self.buy = 10, 10
+
+    def go_short(self):
+        self.sell = 10, 20
+
+    def should_cancel_entry(self):
+        return True
+
+    def on_open_position(self, order):
+        # sell it for $50 profit
+        self.take_profit = self.position.qty, 15

--- a/jesse/testing_utils.py
+++ b/jesse/testing_utils.py
@@ -44,12 +44,12 @@ def get_downtrend_candles(candles_count=100):
     }
 
 
-def get_smooth_sine_candles(candles_count=100):
+def get_smooth_sine_candles(candles_count=100, n_waves=5):
     return {
         jh.key(exchanges.SANDBOX, 'BTC-USDT'): {
             'exchange': exchanges.SANDBOX,
             'symbol': 'BTC-USDT',
-            'candles': smooth_sine_wave_candles(length=candles_count, min_price=5, max_price=25),
+            'candles': smooth_sine_wave_candles(length=candles_count, min_price=5, max_price=25, n_waves=n_waves),
         }
     }
 
@@ -74,6 +74,8 @@ def single_route_backtest(
         leverage=1, leverage_mode='cross', trend='up', fee=0,
         candles_count=100, timeframe='1m',
         start_date='2019-04-01', end_date='2019-04-02',
+        n_waves=5,
+        fast_mode=False,
 ):
     """
     used to simplify simple tests
@@ -86,18 +88,18 @@ def single_route_backtest(
     )
 
     routes = [{'symbol': 'BTC-USDT', 'timeframe': timeframe, 'strategy': strategy_name}]
-
-    if trend == 'up':
-        candles = get_btc_candles(candles_count)
-    elif trend == 'down':
-        candles = get_downtrend_candles(candles_count)
-    elif trend == 'sine':
-        candles = get_smooth_sine_candles(candles_count) # Price fluctuates between 5 and 25, 5 times
-    else:
+    
+    get_candles = {'up': get_btc_candles(candles_count),
+                   'down': get_downtrend_candles(candles_count),
+                   'sine': get_smooth_sine_candles(candles_count, n_waves=n_waves),
+                   }
+    try:
+        candles = get_candles[trend]
+    except:
         raise ValueError
 
     # dates are fake. just to pass required parameters
-    backtest_mode.run('000', False, {}, exchanges.SANDBOX, routes, [], start_date, end_date, candles)
+    backtest_mode.run('000', False, {}, exchanges.SANDBOX, routes, [], start_date, end_date, candles, fast_mode=fast_mode)
 
 
 def two_routes_backtest(

--- a/jesse/testing_utils.py
+++ b/jesse/testing_utils.py
@@ -44,15 +44,12 @@ def get_downtrend_candles(candles_count=100):
     }
 
 
-def get_smooth_sine_candles(candles_count=100, timeframe='1m'):
-    timeframe_to_increment = {'1m' : 60000,
-                              '1D' : 86400000,
-                              }
+def get_smooth_sine_candles(candles_count=100):
     return {
         jh.key(exchanges.SANDBOX, 'BTC-USDT'): {
             'exchange': exchanges.SANDBOX,
             'symbol': 'BTC-USDT',
-            'candles': smooth_sine_wave_candles(length=candles_count, min_price=5, max_price=25, timestamp_increment=timeframe_to_increment[timeframe]),
+            'candles': smooth_sine_wave_candles(length=candles_count, min_price=5, max_price=25),
         }
     }
 
@@ -75,7 +72,8 @@ def set_up(is_futures_trading=True, leverage=1, leverage_mode='cross', fee=0):
 def single_route_backtest(
         strategy_name: str, is_futures_trading=True,
         leverage=1, leverage_mode='cross', trend='up', fee=0,
-        candles_count=100, timeframe='1m'
+        candles_count=100, timeframe='1m',
+        start_date='2019-04-01', end_date='2019-04-02',
 ):
     """
     used to simplify simple tests
@@ -94,12 +92,12 @@ def single_route_backtest(
     elif trend == 'down':
         candles = get_downtrend_candles(candles_count)
     elif trend == 'sine':
-        candles = get_smooth_sine_candles(candles_count, timeframe) # Price fluctuates between 5 and 25, 5 times
+        candles = get_smooth_sine_candles(candles_count) # Price fluctuates between 5 and 25, 5 times
     else:
         raise ValueError
 
     # dates are fake. just to pass required parameters
-    backtest_mode.run('000', False, {}, exchanges.SANDBOX, routes, [], '2019-04-01', '2019-04-02', candles)
+    backtest_mode.run('000', False, {}, exchanges.SANDBOX, routes, [], start_date, end_date, candles)
 
 
 def two_routes_backtest(

--- a/jesse/testing_utils.py
+++ b/jesse/testing_utils.py
@@ -2,6 +2,7 @@ import jesse.helpers as jh
 from jesse.config import reset_config
 from jesse.enums import exchanges
 from jesse.factories import candles_from_close_prices
+from jesse.factories import smooth_sine_wave_candles
 from jesse.modes import backtest_mode
 from jesse.config import config
 
@@ -43,6 +44,19 @@ def get_downtrend_candles(candles_count=100):
     }
 
 
+def get_smooth_sine_candles(candles_count=100, timeframe='1m'):
+    timeframe_to_increment = {'1m' : 60000,
+                              '1D' : 86400000,
+                              }
+    return {
+        jh.key(exchanges.SANDBOX, 'BTC-USDT'): {
+            'exchange': exchanges.SANDBOX,
+            'symbol': 'BTC-USDT',
+            'candles': smooth_sine_wave_candles(length=candles_count, min_price=5, max_price=25, timestamp_increment=timeframe_to_increment[timeframe]),
+        }
+    }
+
+
 def set_up(is_futures_trading=True, leverage=1, leverage_mode='cross', fee=0):
     reset_config()
     config['env']['exchanges'][exchanges.SANDBOX]['balance'] = 10_000
@@ -79,6 +93,8 @@ def single_route_backtest(
         candles = get_btc_candles(candles_count)
     elif trend == 'down':
         candles = get_downtrend_candles(candles_count)
+    elif trend == 'sine':
+        candles = get_smooth_sine_candles(candles_count, timeframe) # Price fluctuates between 5 and 25, 5 times
     else:
         raise ValueError
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -79,7 +79,8 @@ def test_metrics_long_and_short_without_fee():
 
 
 def test_metrics_long_and_short_one_year_without_fee():
-    n_candles = 525600
+    days = 365
+    n_candles = days * 1440  # = 525,600
     single_route_backtest('TestMetrics2', trend='sine', candles_count=n_candles, end_date='2020-04-01')
 
     trades = store.completed_trades.trades
@@ -108,13 +109,16 @@ def test_metrics_long_and_short_one_year_without_fee():
     assert stats['total_open_trades'] == 1
     assert stats['largest_losing_trade'] == 0
     assert 49.9 <= stats['largest_winning_trade'] <= 50
-    expected_annual_return = ((stats['finishing_balance'] / stats['starting_balance']) ** (525600 / n_candles) - 1) * 100
-    assert math.isclose(stats['annual_return'], expected_annual_return, abs_tol=1e-2)
+    expected_annual_return = ((stats['finishing_balance'] / stats['starting_balance']) ** (365 / days) - 1) * 100
+    assert math.isclose(stats['annual_return'], expected_annual_return, abs_tol=1e-1)
     assert stats['max_drawdown'] >= -0.5001 # should never have more than a $50 drawdown
+    expected_calmar_ratio = stats['annual_return'] / abs(stats['max_drawdown']) if stats['max_drawdown'] != 0 else float('inf')
+    assert math.isclose(stats['calmar_ratio'], expected_calmar_ratio, abs_tol=1e-1)
 
 
 def test_metrics_long_and_short_year_and_half_without_fee():
-    n_candles = 788400
+    days = 548
+    n_candles = days * 1440  # = 789,120
     single_route_backtest('TestMetrics2', trend='sine', candles_count=n_candles, end_date='2021-04-01')
 
     trades = store.completed_trades.trades
@@ -143,9 +147,49 @@ def test_metrics_long_and_short_year_and_half_without_fee():
     assert stats['total_open_trades'] == 1
     assert stats['largest_losing_trade'] == 0
     assert 49.9 <= stats['largest_winning_trade'] <= 50
-    expected_annual_return = ((stats['finishing_balance'] / stats['starting_balance']) ** (525600 / n_candles) - 1) * 100
-    assert math.isclose(stats['annual_return'], expected_annual_return, abs_tol=1e-2)
+    expected_annual_return = ((stats['finishing_balance'] / stats['starting_balance']) ** (365 / days) - 1) * 100
+    assert math.isclose(stats['annual_return'], expected_annual_return, abs_tol=1e-1)
     assert stats['max_drawdown'] >= -0.5001 # should never have more than a $50 drawdown
+    expected_calmar_ratio = stats['annual_return'] / abs(stats['max_drawdown']) if stats['max_drawdown'] != 0 else float('inf')
+    assert math.isclose(stats['calmar_ratio'], expected_calmar_ratio, abs_tol=1e-1)
+
+
+def test_metrics_long_and_short_half_year_without_fee():
+    days = 183
+    n_candles = days * 1440  # = 263520
+    single_route_backtest('TestMetrics2', trend='sine', candles_count=n_candles, end_date='2021-04-01')
+
+    trades = store.completed_trades.trades
+    assert len(trades) == 10
+    stats = metrics.trades(store.completed_trades.trades, store.app.daily_balance)
+
+    assert stats['total'] == 10
+    assert stats['starting_balance'] == 10000
+    assert 10499 < stats['finishing_balance'] <= 10500
+    assert stats['longs_percentage'] == 50
+    assert stats['shorts_percentage'] == 50
+    assert stats['fee'] == 0
+    assert 499 < stats['net_profit'] <= 500
+    assert 4.9 < stats['net_profit_percentage'] <= 5
+    assert 49.9 < stats['average_win'] <= 50
+    assert stats['average_loss'] is np.nan
+    assert stats['win_rate'] == 1.0
+    assert stats['winning_streak'] == 10
+    assert stats['longs_count'] == 5
+    assert stats['shorts_count'] == 5
+    assert 49.9 < stats['expectancy'] <= 50
+    assert 0.49 < stats['expectancy_percentage'] <= 0.5
+    assert 49.9 < stats['average_win'] <= 50
+    assert stats['gross_loss'] == 0
+    assert 499 < stats['gross_profit'] <= 500
+    assert stats['total_open_trades'] == 1
+    assert stats['largest_losing_trade'] == 0
+    assert 49.9 <= stats['largest_winning_trade'] <= 50
+    expected_annual_return = ((stats['finishing_balance'] / stats['starting_balance']) ** (365 / days) - 1) * 100
+    assert math.isclose(stats['annual_return'], expected_annual_return, abs_tol=1e-1)
+    assert stats['max_drawdown'] >= -0.5001 # should never have more than a $50 drawdown
+    expected_calmar_ratio = stats['annual_return'] / abs(stats['max_drawdown']) if stats['max_drawdown'] != 0 else float('inf')
+    assert math.isclose(stats['calmar_ratio'], expected_calmar_ratio, abs_tol=1e-1)
 
 
     # ignore metrics that are dependant on daily_returns because the testing candle set is not for multiple dais

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -45,6 +45,38 @@ def test_metrics_for_trades_without_fee():
     assert stats['largest_losing_trade'] == 0
     assert stats['largest_winning_trade'] == 50
 
+
+def test_metrics_long_and_short_without_fee():
+    single_route_backtest('TestMetrics2', trend='sine', candles_count=100)
+
+    trades = store.completed_trades.trades
+    assert len(trades) == 10
+    stats = metrics.trades(store.completed_trades.trades, store.app.daily_balance)
+
+    assert stats['total'] == 10
+    assert stats['starting_balance'] == 10000
+    assert stats['finishing_balance'] == 10500
+    assert stats['longs_percentage'] == 50
+    assert stats['shorts_percentage'] == 50
+    assert stats['fee'] == 0
+    assert 499.9 < stats['net_profit'] <= 500
+    assert 4.9 < stats['net_profit_percentage'] <= 5
+    assert 49.9 < stats['average_win'] <= 50
+    assert stats['average_loss'] is np.nan
+    assert stats['win_rate'] == 1.0
+    assert stats['winning_streak'] == 10
+    assert stats['longs_count'] == 5
+    assert stats['shorts_count'] == 5
+    assert 49.9 < stats['expectancy'] <= 50
+    assert 0.49 < stats['expectancy_percentage'] <= 0.5
+    assert 49.9 < stats['average_win'] <= 50
+    assert stats['gross_loss'] == 0
+    assert 499.9 < stats['gross_profit'] <= 500
+    assert stats['total_open_trades'] == 1
+    assert stats['largest_losing_trade'] == 0
+    assert stats['largest_winning_trade'] == 50
+
+
     # ignore metrics that are dependant on daily_returns because the testing candle set is not for multiple dais
 
 # def test_stats_for_a_strategy_without_losing_trades():


### PR DESCRIPTION
Manually calculated and cross referencing using another library usually produces slightly different metric calculations suggesting some sort of bug or precision issue.

- Fixed an additionally saved balance causing an extra daily return to be used. This is the source of the one off precision errors in various downstream calculations.
- Adjusted the calculations of calmar and cagr to be daily, improving precision to be within 1 decimal of precision.
- Added new sine wave tests.
- Fixed sortino ratio to use sample standard deviation over population, as in finance we usually work with a sample of returns.
- Refactored some of the ratios and cleaned up some dirty code and unnecessary calculations.