### PR TITLE
Optimized _sort_execution_orders().

### DIFF
--- a/jesse/strategies/Strategy.py
+++ b/jesse/strategies/Strategy.py
@@ -69,6 +69,7 @@ class Strategy(ABC):
 
         self._cached_methods = {}
         self._cached_metrics = {}
+        self._current_route_index = None
 
         # Add cached price
         self._cached_price = None
@@ -1318,6 +1319,17 @@ class Strategy(ABC):
     def routes(self) -> List[Route]:
         from jesse.routes import router
         return router.routes
+
+    @property
+    def current_route_index(self) -> int:
+        if self._current_route_index is None:
+            for i, r in enumerate(self.routes):
+                if r.exchange == self.exchange and r.symbol == self.symbol and r.timeframe == self.timeframe:
+                    self._current_route_index = i
+                    break
+            else:
+                self._current_route_index = -1
+        return self._current_route_index
 
     @property
     def leverage(self) -> int:

--- a/jesse/strategies/TestCurrentRouteIndex1/__init__.py
+++ b/jesse/strategies/TestCurrentRouteIndex1/__init__.py
@@ -1,0 +1,16 @@
+from jesse.strategies import Strategy
+
+
+class TestCurrentRouteIndex1(Strategy):
+    def before(self) -> None:
+        if self.index == 0 or self.index == 10:
+            assert self.current_route_index == 0
+
+    def should_long(self):
+        return False
+
+    def go_long(self):
+        pass
+
+    def should_cancel_entry(self):
+        return False

--- a/jesse/strategies/TestCurrentRouteIndex2/__init__.py
+++ b/jesse/strategies/TestCurrentRouteIndex2/__init__.py
@@ -1,0 +1,16 @@
+from jesse.strategies import Strategy
+
+
+class TestCurrentRouteIndex2(Strategy):
+    def before(self) -> None:
+        if self.index == 0 or self.index == 10:
+            assert self.current_route_index == 1
+
+    def should_long(self):
+        return False
+
+    def go_long(self):
+        pass
+
+    def should_cancel_entry(self):
+        return False

--- a/tests/test_parent_strategy.py
+++ b/tests/test_parent_strategy.py
@@ -874,3 +874,7 @@ def test_without_cancel_method():
 
 def test_proper_balance_handling_in_spot_after_order_cancellation():
     single_route_backtest('TestProperBalanceHanldingInSpotAfterOrderCancellation', is_futures_trading=False, trend='down')
+
+
+def test_current_route_index():
+    two_routes_backtest('TestCurrentRouteIndex1', 'TestCurrentRouteIndex2')


### PR DESCRIPTION
- Old implementation has a O(n * m) time complexity.
- New implementation has a O(m * k).
- Where n = len(short_candles), m = len(orders), and k = average number of unmatched orders per step.

Tested locally across 5000+ trades, results are exactly the same as old implementation.