### PR TITLE
 Fix: Add support for line_style='dashed' in horizontal line methods

### DIFF
--- a/jesse/strategies/Strategy.py
+++ b/jesse/strategies/Strategy.py
@@ -103,6 +103,8 @@ class Strategy(ABC):
             lineStyle = 0
         elif line_style == 'dotted':
             lineStyle = 1
+        elif line_style == 'dashed':
+            lineStyle = 2
         else:
             raise ValueError(f"Invalid line_style: {line_style}")
 
@@ -131,6 +133,8 @@ class Strategy(ABC):
             lineStyle = 0
         elif line_style == 'dotted':
             lineStyle = 1
+        elif line_style == 'dashed':
+            lineStyle = 2
         else:
             raise ValueError(f"Invalid line_style: {line_style}")
 


### PR DESCRIPTION
  Fixes #530

  ## Problem
  The `add_horizontal_line_to_candle_chart` and `add_horizontal_line_to_extra_chart`
   methods were rejecting `line_style='dashed'` with a `ValueError`, even though
  dashed lines are documented as supported.

  ## Solution
  Added `'dashed'` as a valid line style option (mapped to lineStyle = 2) in both
  methods.

  ## Changes
  - `jesse/strategies/Strategy.py`: Added elif condition for 'dashed' line style in
  both horizontal line methods

  ## Testing
  Created test script (`test_line_style_fix.py`) that verifies:
  - ✅ Both methods now accept `line_style='dashed'`
  - ✅ Dashed style maps to lineStyle = 2
  - ✅ Existing styles (solid, dotted) still work
  - ✅ Invalid styles still raise appropriate errors