### PR TITLE
fix: add Redis connection resilience for subprocess workers

### DIFF
--- a/jesse/services/redis.py
+++ b/jesse/services/redis.py
@@ -24,7 +24,12 @@ if jh.is_jesse_project():
         async_redis = asyncio.run(init_redis())
         sync_redis = sync_redis_lib.Redis(
             host=ENV_VALUES['REDIS_HOST'], port=ENV_VALUES['REDIS_PORT'], db=int(ENV_VALUES.get('REDIS_DB') or 0),
-            password=ENV_VALUES['REDIS_PASSWORD'] if ENV_VALUES['REDIS_PASSWORD'] else None
+            password=ENV_VALUES['REDIS_PASSWORD'] if ENV_VALUES['REDIS_PASSWORD'] else None,
+            socket_keepalive=True,
+            socket_connect_timeout=10,
+            socket_timeout=60,
+            retry_on_timeout=True,
+            health_check_interval=30,
         )
 
 
@@ -74,4 +79,9 @@ def is_process_active(client_id: str) -> bool:
     if jh.is_unit_testing():
         return False
 
-    return sync_redis.sismember(f"{ENV_VALUES['APP_PORT']}|active-processes", client_id)
+    try:
+        return sync_redis.sismember(f"{ENV_VALUES['APP_PORT']}|active-processes", client_id)
+    except Exception as e:
+        # Don't kill the subprocess on transient Redis errors — assume alive
+        jh.terminal_debug(f"Redis sismember error (assuming active): {e}")
+        return True


### PR DESCRIPTION
## Summary

- Add `socket_keepalive`, `retry_on_timeout`, `socket_connect_timeout`, `socket_timeout`, and `health_check_interval` to the sync Redis client to prevent stale connections in subprocess workers
- Wrap `sismember()` in `is_process_active()` with try/except — returns `True` (assume active) on transient Redis errors instead of crashing the subprocess

## Problem

When Jesse runs in `spawn` mode, each subprocess worker creates its own Redis connection. After prolonged idle periods (common in live trading with infrequent signals) or under CPU throttling, these connections go stale silently. When `is_process_active()` calls `sismember()` on a dead connection, the unhandled `ConnectionError` propagates to `os._exit(1)`, killing the live trading strategy with no useful error message.

This is particularly problematic for live trading where strategies may run for days between signals.

## Test plan

- [x] Verified fix on live trading instance running for 3+ days
- [x] Confirmed `is_process_active()` survives Redis restart without killing strategy
- [x] No regression on normal operation — keepalive and health checks are transparent