### PR TITLE
perf: Switch DynamicNumpyArray to geometric (doubling) growth

### DIFF
--- a/jesse/libs/dynamic_numpy_array/__init__.py
+++ b/jesse/libs/dynamic_numpy_array/__init__.py
@@ -69,10 +69,16 @@ class DynamicNumpyArray:
     def append(self, item: np.ndarray) -> None:
         self.index += 1
 
-        # expand if the arr is almost full
-        if self.index != 0 and (self.index + 1) % self.bucket_size == 0:
-            new_bucket = np.zeros(self.shape)
-            self.array = np.concatenate((self.array, new_bucket), axis=0)
+        # Grow the buffer when full, doubling capacity (geometric growth) so
+        # that total bytes copied across all appends is O(N) rather than the
+        # O(N^2 / bucket_size) of linear-bucket growth via np.concatenate.
+        if self.index >= len(self.array):
+            new_size = max(len(self.array) * 2, max(self.bucket_size, 1))
+            new_shape = (new_size,) + tuple(self.array.shape[1:])
+            new_array = np.zeros(new_shape, dtype=self.array.dtype)
+            if self.index > 0:
+                new_array[:self.index] = self.array[:self.index]
+            self.array = new_array
 
         # drop N% of the beginning values to free memory
         if (
@@ -109,18 +115,21 @@ class DynamicNumpyArray:
         self.bucket_size = self.shape[0]
 
     def append_multiple(self, items: np.ndarray) -> None:
-        self.index += len(items)
+        n_new = len(items)
+        old_index = self.index
+        self.index += n_new
 
-        # expand if the arr will be greater than the maximum
-        if self.index != 0 and (self.index + 1) >= len(self.array):
-            # in case the shape is smaller than  len(items)
-            if isinstance(self.shape, int):
-                shape = max(self.shape, len(items))
-            else:
-                shape = list(self.shape)
-                shape[0] = max(len(items), shape[0])
-            new_bucket = np.zeros(shape)
-            self.array = np.concatenate((self.array, new_bucket), axis=0)
+        # Grow the buffer geometrically (double) when needed. Must accommodate
+        # `self.index + 1` total elements; ensure we double-or-better to avoid
+        # degrading to linear growth when many small batches are appended.
+        if self.index + 1 > len(self.array):
+            min_required = self.index + 1
+            new_size = max(min_required, len(self.array) * 2, max(self.bucket_size, 1))
+            new_shape = (new_size,) + tuple(self.array.shape[1:])
+            new_array = np.zeros(new_shape, dtype=self.array.dtype)
+            if old_index >= 0:
+                new_array[:old_index + 1] = self.array[:old_index + 1]
+            self.array = new_array
 
         # drop N% of the beginning values to free memory
         if (
@@ -132,7 +141,7 @@ class DynamicNumpyArray:
             self.index -= shift_num
             self.array = np_shift(self.array, -shift_num)
 
-        self.array[self.index - len(items) + 1 : self.index + 1] = items
+        self.array[self.index - n_new + 1 : self.index + 1] = items
 
     def delete(self, index: int, axis=None) -> None:
         self.array = np.delete(self.array, index, axis=axis)

--- a/tests/test_dynamic_numpy_array.py
+++ b/tests/test_dynamic_numpy_array.py
@@ -95,6 +95,12 @@ def test_get_item():
 
 
 def test_array_size_increases():
+    """Verify the buffer grows to accommodate appends.
+
+    The exact post-grow shape is an implementation detail (linear-bucket vs
+    geometric); what matters behaviorally is that all appended values are
+    retained correctly and the buffer has at least enough capacity.
+    """
     a = DynamicNumpyArray((3, 6))
 
     assert a.array.shape == (3, 6)
@@ -102,14 +108,70 @@ def test_array_size_increases():
     a.append(np.array([1, 2, 3, 4, 5, 6]))
     a.append(np.array([7, 8, 9, 10, 11, 12]))
     a.append(np.array([13, 14, 15, 16, 17, 18]))
-    assert a.array.shape == (6, 6)
+    assert a.array.shape[0] >= 3
+    assert a.array.shape[1] == 6
     assert a.index == 2
+    np.testing.assert_array_equal(a[0], np.array([1, 2, 3, 4, 5, 6]))
+    np.testing.assert_array_equal(a[2], np.array([13, 14, 15, 16, 17, 18]))
 
     a.append(np.array([19, 20, 21, 22, 23, 24]))
     a.append(np.array([25, 26, 27, 28, 29, 30]))
     a.append(np.array([31, 32, 33, 34, 35, 36]))
-    assert a.array.shape == (9, 6)
+    assert a.array.shape[0] >= 6
+    assert a.array.shape[1] == 6
     assert a.index == 5
+    np.testing.assert_array_equal(a[5], np.array([31, 32, 33, 34, 35, 36]))
+
+
+def test_geometric_growth_pattern():
+    """The number of buffer reallocations across N appends should be O(log N),
+    not O(N/bucket_size). This guards against accidental regression to linear
+    growth (which produces O(N^2) total memcpy on long backtests)."""
+    a = DynamicNumpyArray((4, 6))
+    n_appends = 5000
+
+    sizes_seen = [a.array.shape[0]]
+    for i in range(n_appends):
+        a.append(np.array([i, i + 1, i + 2, i + 3, i + 4, i + 5]))
+        if a.array.shape[0] != sizes_seen[-1]:
+            sizes_seen.append(a.array.shape[0])
+
+    # log2(5000/4) ≈ 10.3 — we should see at most ~12 distinct sizes.
+    assert len(sizes_seen) <= 14, (
+        f"too many growths ({len(sizes_seen)}): {sizes_seen}"
+    )
+    # Each growth at least 1.5× the prior — prevents accidental linear growth
+    for prev, nxt in zip(sizes_seen, sizes_seen[1:]):
+        assert nxt >= prev * 1.5, (
+            f"growth from {prev} to {nxt} is sub-geometric"
+        )
+
+    # Spot-check correctness — appends should be intact in order
+    np.testing.assert_array_equal(a[0], np.array([0, 1, 2, 3, 4, 5]))
+    np.testing.assert_array_equal(a[2500], np.array([2500, 2501, 2502, 2503, 2504, 2505]))
+    np.testing.assert_array_equal(a[n_appends - 1], np.array([4999, 5000, 5001, 5002, 5003, 5004]))
+
+
+def test_append_multiple_grows_geometrically():
+    """append_multiple should also use geometric growth and produce identical
+    final state to the equivalent sequence of append() calls."""
+    via_multiple = DynamicNumpyArray((10, 6))
+    via_single = DynamicNumpyArray((10, 6))
+
+    rng = np.random.default_rng(seed=42)
+    n_batches = 30
+    batch_size = 25
+    for _ in range(n_batches):
+        batch = rng.standard_normal((batch_size, 6))
+        via_multiple.append_multiple(batch)
+        for row in batch:
+            via_single.append(row)
+
+    assert via_multiple.index == via_single.index
+    np.testing.assert_array_equal(
+        via_multiple.array[:via_multiple.index + 1],
+        via_single.array[:via_single.index + 1],
+    )
 
 
 def test_drop_at():


### PR DESCRIPTION
## What this is

I was profiling a Jesse HPO setup that was running surprisingly slowly on a high-core-count AMD machine, and the trail led back to one method in `DynamicNumpyArray`: `append`. The way the buffer grows under the hood is doing a `np.concatenate` every `bucket_size` appends, which copies the entire existing array each time. For a long backtest (3.1M candles in my case), that adds up to roughly **80 billion element-copies per backtest** — the algorithm is O(N²/bucket_size) in total bytes copied.

This PR swaps that for textbook geometric growth: when the buffer fills up, allocate a new buffer twice as big and copy the existing data once. Same amortized O(1) per append that Python's `list` and C++ `std::vector` use, total bytes copied across N appends becomes O(N). For my 3.1M-candle case that's ~6 million element-copies instead of 80 billion. Three orders of magnitude fewer copies.

## Why I noticed

I was running a 100-trial Optuna parameter sweep with 20 Ray jobs on a Threadripper Pro 5995WX and seeing wildly degrading per-trial cost — the first trial in each Ray worker would take ~60 seconds, the fifth would take ~700 seconds. Same code, same data, just a worker that had handled a few backtests already.

After a fairly long detour through OS tuning, I instrumented the workload three ways at once: per-trial cProfile inside each Ray worker, an external memory bandwidth probe running every 5 seconds in a separate process, and CPU frequency snapshots. All three pointed at the same thing.

cProfile showed `candle_service.add_candle` (and its call into `DynamicNumpyArray.append`) cumulative time growing from 38 s on the first call to 605 s on the fourth — same backtest, same number of candles, same parameters. Something about repeating the operation was making it dramatically more expensive each time.

The bandwidth probe was the smoking gun. Run alone the probe reports about 23 GB/s. While the slow phase of the workload was running, the probe was getting **0.06 GB/s** — the workload was eating ~99.7% of the system's memory bandwidth. CPU frequency was happily at boost throughout, so cores were fine; they were just stalled waiting for DRAM.

The mechanism makes sense in hindsight. Each `np.concatenate` copies the existing array — that's bandwidth-heavy memcpy. Run 20 backtests concurrently and you're saturating the system bus. And since glibc's heap fragments a bit each time you free a 1.6 GB array and allocate a new one, subsequent backtests in the same process do *more* memory work for the same logical operation. The first backtest's allocations land cleanly; by the fifth, the allocator is doing significantly more work to satisfy the same request.

## What changed

Two methods in `jesse/libs/dynamic_numpy_array/__init__.py`:

**`append`**: was

```python
if self.index != 0 and (self.index + 1) % self.bucket_size == 0:
    new_bucket = np.zeros(self.shape)
    self.array = np.concatenate((self.array, new_bucket), axis=0)
```

is now

```python
if self.index >= len(self.array):
    new_size = max(len(self.array) * 2, max(self.bucket_size, 1))
    new_shape = (new_size,) + tuple(self.array.shape[1:])
    new_array = np.zeros(new_shape, dtype=self.array.dtype)
    if self.index > 0:
        new_array[:self.index] = self.array[:self.index]
    self.array = new_array
```

**`append_multiple`**: same pattern — grow when the new batch wouldn't fit, sized to `max(min_required, current * 2, bucket_size)` so even a sequence of large batches doesn't degrade to linear growth. Everything else stays the same. 

## Tests

The existing `test_array_size_increases` was asserting specific post-grow shapes (`(6, 6)` after 3 appends, `(9, 6)` after 6 appends). Those numbers were specific to the linear-bucket implementation — geometric growth produces different intermediate shapes. I updated that test to assert behavioral correctness (capacity sufficient to hold the data, values intact, index correct) rather than the implementation-specific shape numbers. All other tests in `tests/test_dynamic_numpy_array.py` pass unchanged.

I added two new tests as regression guards:

- `test_geometric_growth_pattern`: appends 5000 items into an array that started at size 4, asserts that fewer than 14 distinct buffer sizes were seen (geometric should be ~11; linear-bucket would be ~1250). Each successive size has to be at least 1.5× the previous, so an accidental refactor back to linear growth would fail loudly.
- `test_append_multiple_grows_geometrically`: appends a bunch of batches via `append_multiple` and the equivalent stream of single appends, asserts the final array contents are bit-for-bit identical.

## Numbers

Real-world impact on a 100-trial Optuna parameter sweep, Ray jobs=20, multi-route 1m+30m+4h candles for BTC-USDT 2019–2026, Threadripper Pro 5995WX with DDR4-2666:

| | Wall (100 trials) | Per-trial | Per-call cost across 5 calls in a worker | Memory BW available during run |
|---|---:|---:|---|---:|
| Linear-bucket (current) | 1523 s | 15.2 s/trial | 60 → 660 s, 11× growth | 0.06–4.7 GB/s (bus saturated) |
| **This PR** | **310 s** | **3.10 s/trial** | **60 → 60 s, flat** | **22 GB/s (essentially solo)** |

The patched run hits 96.7% parallel efficiency (310 s actual vs 300 s theoretical for `5 batches × 60 s/trial`). Within-worker degradation is gone — every call takes essentially the same amount of time.

## Trade-offs

The one real trade-off is peak memory footprint. With linear-bucket growth, an array might grow to `N + bucket_size` then sit there. With doubling, it could reach up to `2N` in the worst case (just after a doubling, with nothing else added). For a workload that grows to 3.1M elements at 8 bytes each, that's a difference of a few hundred MB extra peak vs the previous behavior. In exchange you don't generate tens of GB of redundant memory traffic per backtest, so the trade is heavily favorable in any environment where memory bandwidth matters.

I considered adding a `final_size` parameter that the caller could set to pre-allocate the right size up front (which would be marginally faster — exactly N writes instead of geometric's ~2N writes). But that's a breaking API change to `__init__` and requires every call site that constructs a `DynamicNumpyArray` to know its final size. Geometric growth is amortized O(1) per append with the existing API and is asymptotically equivalent, so I didn't bother.

## A side note on the diagnostic process

If anyone hits weird HPO performance issues in the future, the most useful single diagnostic for me was running a STREAM-style memory bandwidth probe in a separate process every few seconds during the workload. Solo it reads ~23 GB/s; while the workload is running, what it reports is just whatever bandwidth the workload isn't consuming. When that drops to near zero, you know you're memory-bandwidth bound and the only fix is changing how much memory traffic you're generating. cProfile of individual calls plus that probe localized this issue in about 25 minutes after weeks of looking in the wrong places.

Happy to provide more measurements or run additional benchmarks if useful for review.
