### PR TITLE
perf: eliminate redundant numpy copies in backtest hot path

### DIFF
--- a/jesse/modes/backtest_mode.py
+++ b/jesse/modes/backtest_mode.py
@@ -1200,7 +1200,8 @@ def _update_all_routes_a_partial_candle(
             continue
         tf_minutes = TIMEFRAME_TO_ONE_MINUTES[timeframe]
         number_of_needed_candles = int(storable_temp_candle[0] % (tf_minutes * 60_000) // 60000) + 1
-        candles_1m = candle_service.get_candles(exchange, symbol, '1m')[-number_of_needed_candles:]
+        arr_1m = store.candles.get_storage(exchange, symbol, '1m')
+        candles_1m = arr_1m[-number_of_needed_candles:]
         generated_candle = candle_service.generate_candle_from_one_minutes(
             timeframe,
             candles_1m,

--- a/jesse/services/candle_service.py
+++ b/jesse/services/candle_service.py
@@ -557,8 +557,9 @@ def _generate_bigger_timeframes(candle: np.ndarray, exchange: str, symbol: str, 
 
         last_candle = get_current_candle(exchange, symbol, timeframe)
         generate_from_count = int((candle[0] - last_candle[0]) / 60_000)
-        number_of_candles = len(get_candles(exchange, symbol, '1m'))
-        short_candles = get_candles(exchange, symbol, '1m')[-1 - generate_from_count:]
+        candles_1m = get_candles(exchange, symbol, '1m')
+        number_of_candles = len(candles_1m)
+        short_candles = candles_1m[-1 - generate_from_count:]
 
         if generate_from_count == -1:
             # it's receiving an slightly older candle than the last one. Ignore it

--- a/jesse/strategies/Strategy.py
+++ b/jesse/strategies/Strategy.py
@@ -1368,7 +1368,7 @@ class Strategy(ABC):
 
         :return: np.ndarray
         """
-        return candle_service.get_current_candle(self.exchange, self.symbol, self.timeframe).copy()
+        return candle_service.get_current_candle(self.exchange, self.symbol, self.timeframe)
 
     @property
     def open(self) -> float:


### PR DESCRIPTION
## Summary

Multiple redundant array operations in the backtest execution path create unnecessary overhead. While `DynamicNumpyArray.__getitem__(slice)` already returns views (not copies) for `get_candles()`, there are still avoidable redundant operations:

1. `Strategy.current_candle` calls `.copy()` on every access — and the `open`, `close`, `high`, `low`, `volume` properties each invoke `current_candle`, creating 5 redundant copies per property chain
2. `_generate_bigger_timeframes` calls `get_candles()` twice for identical exchange/symbol/1m data
3. `_update_all_routes_a_partial_candle` calls `get_candles()` to fetch the full 1m candle array just to slice the last N candles

## Changes

### `jesse/strategies/Strategy.py`
- Removed `.copy()` from `current_candle` property. `get_current_candle()` returns either a new array (from `generate_candle_from_one_minutes()`) or a view into `DynamicNumpyArray` storage — both are safe to return directly since **all callers are read-only** (verified by full codebase audit: no in-place mutations of `current_candle`, `self.candles`, or `self.open/close/high/low` anywhere in the framework or tests).

### `jesse/services/candle_service.py`
- `_generate_bigger_timeframes`: cached `get_candles(exchange, symbol, '1m')` result in a local variable instead of calling it twice (once for `len()` and once for the slice).

### `jesse/modes/backtest_mode.py`
- `_update_all_routes_a_partial_candle`: replaced `candle_service.get_candles(exchange, symbol, '1m')[-N:]` with direct store access `store.candles.get_storage(exchange, symbol, '1m')[-N:]`, avoiding the overhead of the full `get_candles()` function (forming estimation logic, multiple store lookups) when only the last N candles are needed.

## Testing
- Verified backtest correctness with the `current_candle` change (no `.copy()`) using `research.backtest()` with and without warmup candles
- Full codebase audit confirmed zero in-place mutations of returned candle arrays

## Tradeoffs
- `current_candle` now returns a view into internal storage instead of a copy. If user strategy code stores the reference and reads it after `add_candle()` has been called (next candle), the view would reflect the updated data. This is acceptable because: (a) within a single `_execute()` cycle, no `add_candle` is called; (b) all framework-internal callers only read scalar values immediately.