### PR TITLE
refactor: replace 118 duplicated auth checks with FastAPI Depends() dependency

### DIFF
--- a/jesse/controllers/backtest_controller.py
+++ b/jesse/controllers/backtest_controller.py
@@ -1,8 +1,7 @@
 from typing import Optional
-from fastapi import APIRouter, Header, Query, Body
+from fastapi import APIRouter, Header, Query, Body, Depends
 from fastapi.responses import JSONResponse, FileResponse
 import json
-from jesse.services import auth as authenticator
 from jesse.services.multiprocessing import process_manager
 from jesse.services.web import BacktestRequestJson, CancelRequestJson, UpdateBacktestSessionStateRequestJson, GetBacktestSessionsRequestJson, UpdateBacktestSessionNotesRequestJson
 import jesse.helpers as jh
@@ -19,6 +18,7 @@ from jesse.services.transformers import get_backtest_session, get_backtest_sessi
 from jesse.modes.backtest_mode import run as run_backtest
 from jesse.modes.data_provider import get_backtest_logs, download_backtest_log
 import os
+from jesse.services.auth import require_auth, require_auth_token, require_auth_any
 
 
 
@@ -26,12 +26,11 @@ router = APIRouter(prefix="/backtest", tags=["Backtest"])
 
 
 @router.post("")
-def backtest(request_json: BacktestRequestJson, authorization: Optional[str] = Header(None)):
+def backtest(request_json: BacktestRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Start a backtest process
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     jh.validate_cwd()
 
@@ -66,15 +65,13 @@ def get_charts_image(
     session_id: str,
     chart: str,
     token: Optional[str] = None,
-    authorization: Optional[str] = Header(None)
+    authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth_any)
 ):
     """
     Serve a chart PNG image for a specific backtest session.
     chart param must be one of: equity_curve, drawdown, underwater, monthly_heatmap, monthly_distribution, trade_pnl
     """
-    effective_auth = token or authorization
-    if not authenticator.is_valid_token(effective_auth):
-        return authenticator.unauthorized_response()
 
     if chart not in BACKTEST_CHART_NAMES:
         return JSONResponse({'error': f'Unknown chart name: {chart}'}, status_code=400)
@@ -89,12 +86,11 @@ def get_charts_image(
 
 
 @router.post("/cancel")
-def cancel_backtest(request_json: CancelRequestJson, authorization: Optional[str] = Header(None)):
+def cancel_backtest(request_json: CancelRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Cancel a backtest process
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     process_manager.cancel_process(request_json.id)
     
@@ -105,12 +101,10 @@ def cancel_backtest(request_json: CancelRequestJson, authorization: Optional[str
 
 
 @router.get("/logs/{session_id}")
-def get_logs(session_id: str, token: str = Query(...)):
+def get_logs(session_id: str, token: str = Query(...), _auth: None = Depends(require_auth_token)):
     """
     Get logs as text for a specific session. Similar to download but returns text content instead of file.
     """
-    if not authenticator.is_valid_token(token):
-        return authenticator.unauthorized_response()
 
     try:
         content = get_backtest_logs(session_id)
@@ -124,12 +118,10 @@ def get_logs(session_id: str, token: str = Query(...)):
 
 
 @router.get("/download-log/{session_id}")
-def download_backtest_log_handler(session_id: str, token: str = Query(...)):
+def download_backtest_log_handler(session_id: str, token: str = Query(...), _auth: None = Depends(require_auth_token)):
     """
     Download log file for a specific backtest session
     """
-    if not authenticator.is_valid_token(token):
-        return authenticator.unauthorized_response()
 
     try:
         return download_backtest_log(session_id)
@@ -138,12 +130,11 @@ def download_backtest_log_handler(session_id: str, token: str = Query(...)):
 
 
 @router.post("/sessions")
-def get_backtest_sessions(request_json: GetBacktestSessionsRequestJson = Body(default=GetBacktestSessionsRequestJson()), authorization: Optional[str] = Header(None)):
+def get_backtest_sessions(request_json: GetBacktestSessionsRequestJson = Body(default=GetBacktestSessionsRequestJson()), authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get a list of backtest sessions sorted by most recently updated with pagination
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     # Get sessions from the database with pagination and filters
     sessions = get_sessions(
@@ -164,12 +155,11 @@ def get_backtest_sessions(request_json: GetBacktestSessionsRequestJson = Body(de
 
 
 @router.post("/sessions/{session_id}")
-def get_backtest_session_by_id(session_id: str, authorization: Optional[str] = Header(None)):
+def get_backtest_session_by_id(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get a single backtest session by ID
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     # Get the session from the database
     session = get_backtest_session_by_id_from_db(session_id)
@@ -189,12 +179,11 @@ def get_backtest_session_by_id(session_id: str, authorization: Optional[str] = H
 
 
 @router.post("/update-state")
-def update_session_state(request_json: UpdateBacktestSessionStateRequestJson, authorization: Optional[str] = Header(None)):
+def update_session_state(request_json: UpdateBacktestSessionStateRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Update the state of a backtest session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     update_backtest_session_state(request_json.id, request_json.state)
 
@@ -204,12 +193,11 @@ def update_session_state(request_json: UpdateBacktestSessionStateRequestJson, au
 
 
 @router.post("/sessions/{session_id}/remove")
-def remove_backtest_session(session_id: str, authorization: Optional[str] = Header(None)):
+def remove_backtest_session(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Remove a backtest session from the database
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     session = get_backtest_session_by_id_from_db(session_id)
 
@@ -232,12 +220,11 @@ def remove_backtest_session(session_id: str, authorization: Optional[str] = Head
 
 
 @router.post("/sessions/{session_id}/notes")
-def update_session_notes(session_id: str, request_json: UpdateBacktestSessionNotesRequestJson, authorization: Optional[str] = Header(None)):
+def update_session_notes(session_id: str, request_json: UpdateBacktestSessionNotesRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Update the notes (title, description, strategy_codes) of a backtest session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     session = get_backtest_session_by_id_from_db(session_id)
 
@@ -254,12 +241,11 @@ def update_session_notes(session_id: str, request_json: UpdateBacktestSessionNot
 
 
 @router.post("/purge-sessions")
-def purge_sessions(request_json: dict = Body(...), authorization: Optional[str] = Header(None)):
+def purge_sessions(request_json: dict = Body(...), authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Purge backtest sessions older than specified days
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
     
     days_old = request_json.get('days_old', None)
     
@@ -272,12 +258,11 @@ def purge_sessions(request_json: dict = Body(...), authorization: Optional[str] 
 
 
 @router.post("/sessions/{session_id}/chart-data")
-def get_backtest_session_chart_data(session_id: str, authorization: Optional[str] = Header(None)):
+def get_backtest_session_chart_data(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get chart data for a specific backtest session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     session = get_backtest_session_by_id_from_db(session_id)
 
@@ -294,12 +279,11 @@ def get_backtest_session_chart_data(session_id: str, authorization: Optional[str
 
 
 @router.post("/sessions/{session_id}/strategy-code")
-def get_backtest_session_strategy_codes(session_id: str, authorization: Optional[str] = Header(None)):
+def get_backtest_session_strategy_codes(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get strategy codes for a specific backtest session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     session = get_backtest_session_by_id_from_db(session_id)
 

--- a/jesse/controllers/candles_controller.py
+++ b/jesse/controllers/candles_controller.py
@@ -1,8 +1,8 @@
+from jesse.services.auth import require_auth
 from typing import Optional
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Header, Depends
 from starlette.responses import JSONResponse
 from jesse.repositories import candle_repository
-from jesse.services import auth as authenticator
 from jesse.services.multiprocessing import process_manager
 from jesse.services.web import ImportCandlesRequestJson, CancelRequestJson, GetCandlesRequestJson, DeleteCandlesRequestJson, PurgeCandlesRequestJson
 import jesse.helpers as jh
@@ -11,14 +11,13 @@ router = APIRouter(prefix="/candles", tags=["Candles"])
 
 
 @router.post("/import")
-def import_candles(request_json: ImportCandlesRequestJson, authorization: Optional[str] = Header(None)) -> JSONResponse:
+def import_candles(request_json: ImportCandlesRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Import candles for a specific exchange and symbol
     """
     jh.validate_cwd()
 
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     from jesse.modes import import_candles_mode
 
@@ -34,12 +33,11 @@ def import_candles(request_json: ImportCandlesRequestJson, authorization: Option
 
 
 @router.post("/cancel-import")
-def cancel_import_candles(request_json: CancelRequestJson, authorization: Optional[str] = Header(None)):
+def cancel_import_candles(request_json: CancelRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Cancel an import candles process
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     process_manager.cancel_process(request_json.id)
 
@@ -48,12 +46,11 @@ def cancel_import_candles(request_json: CancelRequestJson, authorization: Option
 
 
 @router.post("/clear-cache")
-def clear_candles_database_cache(authorization: Optional[str] = Header(None)):
+def clear_candles_database_cache(authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Clear the candles database cache
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     from jesse.services.cache import cache
     cache.flush()
@@ -65,12 +62,11 @@ def clear_candles_database_cache(authorization: Optional[str] = Header(None)):
 
 
 @router.post("/get")
-def get_candles(json_request: GetCandlesRequestJson, authorization: Optional[str] = Header(None)) -> JSONResponse:
+def get_candles(json_request: GetCandlesRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Get candles for a specific exchange, symbol, and timeframe
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     jh.validate_cwd()
 
@@ -85,12 +81,11 @@ def get_candles(json_request: GetCandlesRequestJson, authorization: Optional[str
 
 
 @router.post("/existing")
-def get_existing_candles(authorization: Optional[str] = Header(None)) -> JSONResponse:
+def get_existing_candles(authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Get all existing candles in the database
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
     
     try:
         data = candle_repository.get_existing_candles()
@@ -100,12 +95,11 @@ def get_existing_candles(authorization: Optional[str] = Header(None)) -> JSONRes
 
 
 @router.post("/delete")
-def delete_candles(json_request: DeleteCandlesRequestJson, authorization: Optional[str] = Header(None)) -> JSONResponse:
+def delete_candles(json_request: DeleteCandlesRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Delete candles for a specific exchange and symbol
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     try:
         candle_repository.delete_candles_from_db(json_request.exchange, json_request.symbol)
@@ -115,12 +109,11 @@ def delete_candles(json_request: DeleteCandlesRequestJson, authorization: Option
 
 
 @router.post("/purge")
-def purge_candles(json_request: PurgeCandlesRequestJson, authorization: Optional[str] = Header(None)) -> JSONResponse:
+def purge_candles(json_request: PurgeCandlesRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Delete all candles for the given list of exchanges
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     try:
         deleted_count = candle_repository.purge_candles_by_exchanges(json_request.exchanges)

--- a/jesse/controllers/closed_trade_controller.py
+++ b/jesse/controllers/closed_trade_controller.py
@@ -1,8 +1,8 @@
+from jesse.services.auth import require_auth
 from typing import Optional
-from fastapi import APIRouter, Header, Query, Body
+from fastapi import APIRouter, Header, Query, Body, Depends
 from fastapi.responses import JSONResponse
 
-from jesse.services import auth as authenticator
 from jesse.repositories import closed_trade_repository
 from jesse.services.transformers import get_closed_trade_for_list, get_closed_trade_details
 from jesse.services.web import GetTradesHistoryRequestJson
@@ -14,10 +14,9 @@ router = APIRouter(prefix="/closed-trades", tags=["Closed Trades"])
 def get_closed_trades(
     session_id: str = Query(...), 
     limit: int = Query(10, ge=1, le=1000),
-    authorization: Optional[str] = Header(None)
+    authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ) -> JSONResponse:
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
     
     try:
         # Query trades for the session with limit
@@ -36,9 +35,8 @@ def get_closed_trades(
 
 
 @router.get("/{trade_id}")
-def get_closed_trade_by_id(trade_id: str, authorization: Optional[str] = Header(None)) -> JSONResponse:
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
+def get_closed_trade_by_id(trade_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     
     try:
         # Fetch trade by ID
@@ -64,10 +62,9 @@ def get_closed_trade_by_id(trade_id: str, authorization: Optional[str] = Header(
 @router.post("/live-history")
 def get_trades_live_history(
     request_json: GetTradesHistoryRequestJson = Body(...),
-    authorization: Optional[str] = Header(None)
+    authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ) -> JSONResponse:
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     try:
         # Fetch trades with filters

--- a/jesse/controllers/config_controller.py
+++ b/jesse/controllers/config_controller.py
@@ -1,8 +1,8 @@
+from jesse.services.auth import require_auth
 from typing import Optional
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Header, Depends
 from fastapi.responses import JSONResponse
 
-from jesse.services import auth as authenticator
 from jesse.services.web import ConfigRequestJson
 import jesse.helpers as jh
 
@@ -10,12 +10,11 @@ router = APIRouter(prefix="/config", tags=["Configuration"])
 
 
 @router.post("/get")
-def get_config(json_request: ConfigRequestJson, authorization: Optional[str] = Header(None)):
+def get_config(json_request: ConfigRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get the current configuration
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     from jesse.modes.data_provider import get_config as gc
 
@@ -25,12 +24,11 @@ def get_config(json_request: ConfigRequestJson, authorization: Optional[str] = H
 
 
 @router.post("/update")
-def update_config(json_request: ConfigRequestJson, authorization: Optional[str] = Header(None)):
+def update_config(json_request: ConfigRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Update the configuration
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     from jesse.modes.data_provider import update_config as uc
 

--- a/jesse/controllers/exchange_controller.py
+++ b/jesse/controllers/exchange_controller.py
@@ -1,10 +1,10 @@
 from typing import Optional
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Header, Depends
 from starlette.responses import JSONResponse
 
 from jesse.modes.import_candles_mode import CandleExchange
 from jesse.modes.import_candles_mode.drivers import drivers, driver_names
-from jesse.services import auth as authenticator
+from jesse.services.auth import require_auth
 from jesse.services.redis import sync_redis
 from jesse.services.web import ExchangeSupportedSymbolsRequestJson, StoreExchangeApiKeyRequestJson, DeleteExchangeApiKeyRequestJson
 from jesse.services.env import is_dev_env
@@ -14,10 +14,7 @@ router = APIRouter(prefix="/exchange", tags=["Exchange"])
 
 
 @router.post('/supported-symbols')
-def exchange_supported_symbols(request_json: ExchangeSupportedSymbolsRequestJson, authorization: Optional[str] = Header(None)) -> JSONResponse:
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
-    
+def exchange_supported_symbols(request_json: ExchangeSupportedSymbolsRequestJson, authorization: Optional[str] = Header(None), _auth: None = Depends(require_auth)) -> JSONResponse:
     # if is_dev_env():
     #     return JSONResponse({
     #         'data': [    
@@ -29,19 +26,13 @@ def exchange_supported_symbols(request_json: ExchangeSupportedSymbolsRequestJson
 
 
 @router.get('/api-keys')
-def get_exchange_api_keys_endpoint(authorization: Optional[str] = Header(None)) -> JSONResponse:
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
-
+def get_exchange_api_keys_endpoint(authorization: Optional[str] = Header(None), _auth: None = Depends(require_auth)) -> JSONResponse:
     from jesse.modes.exchange_api_keys import get_exchange_api_keys
     return get_exchange_api_keys()
 
 
 @router.post('/api-keys/store')
-def store_exchange_api_keys_endpoint(json_request: StoreExchangeApiKeyRequestJson,
-                        authorization: Optional[str] = Header(None)) -> JSONResponse:
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
+def store_exchange_api_keys_endpoint(json_request: StoreExchangeApiKeyRequestJson, authorization: Optional[str] = Header(None), _auth: None = Depends(require_auth)) -> JSONResponse:
 
     from jesse.modes.exchange_api_keys import store_exchange_api_keys
     return store_exchange_api_keys(
@@ -51,10 +42,7 @@ def store_exchange_api_keys_endpoint(json_request: StoreExchangeApiKeyRequestJso
 
 
 @router.post('/api-keys/delete')
-def delete_exchange_api_keys_endpoint(json_request: DeleteExchangeApiKeyRequestJson,
-                         authorization: Optional[str] = Header(None)) -> JSONResponse:
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
+def delete_exchange_api_keys_endpoint(json_request: DeleteExchangeApiKeyRequestJson, authorization: Optional[str] = Header(None), _auth: None = Depends(require_auth)) -> JSONResponse:
 
     from jesse.modes.exchange_api_keys import delete_exchange_api_keys
     return delete_exchange_api_keys(json_request.id)

--- a/jesse/controllers/file_controller.py
+++ b/jesse/controllers/file_controller.py
@@ -1,7 +1,7 @@
-from fastapi import APIRouter, Query, Header, UploadFile, Form, File
+from fastapi import APIRouter, Query, Header, UploadFile, Form, File, Depends
 from typing import Optional
 
-from jesse.services import auth as authenticator
+from jesse.services.auth import require_auth, require_auth_token, unauthorized_response
 from jesse.modes import data_provider
 from jesse.services.web import ImportApiKeyRequestJson, LoginRequestJson
 from jesse.services.env import ENV_VALUES
@@ -10,31 +10,24 @@ router = APIRouter(prefix="/download", tags=["Download"])
 
 
 @router.get("/{mode}/{file_type}/{session_id}")
-def download(mode: str, file_type: str, session_id: str, token: str = Query(...)):
+def download(mode: str, file_type: str, session_id: str, token: str = Query(...), _auth: None = Depends(require_auth_token)):
     """
     Download files such as logs or other generated files.
     Log files require session_id because there is one log per each session. Except for the optimize mode.
     """
-    if not authenticator.is_valid_token(token):
-        return authenticator.unauthorized_response()
-
     return data_provider.download_file(mode, file_type, session_id)
 
 
 @router.post("/download-api-keys")
 def download_api_keys(
     request_json: LoginRequestJson,
-    authorization: Optional[str] = Header(None)
+    authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ):
-    """
-    Download exchange API Keys - requires password verification
-    """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     # Verify password for this sensitive operation
     if request_json.password != ENV_VALUES['PASSWORD']:
-        return authenticator.unauthorized_response()
+        return unauthorized_response()
 
     jh.validate_cwd()
 
@@ -44,13 +37,9 @@ def download_api_keys(
 @router.post("/import-api-keys")
 async def import_api_keys(
     request_json: ImportApiKeyRequestJson,
-    authorization: Optional[str] = Header(None)
+    authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ):
-    """
-    Import exchange API keys from CSV text received in the request body.
-    """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     try:
         # remove leading/trailing whitespace
@@ -77,16 +66,12 @@ async def import_api_keys(
 @router.post("/download-notification-api-keys")
 def download_notification_api_keys(
     request_json: LoginRequestJson,
-    authorization: Optional[str] = Header(None)
+    authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ):
-    """
-    Download notification API keys - requires password verification
-    """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     if request_json.password != ENV_VALUES['PASSWORD']:
-        return authenticator.unauthorized_response()
+        return unauthorized_response()
 
     jh.validate_cwd()
 
@@ -96,13 +81,9 @@ def download_notification_api_keys(
 @router.post("/import-notification-api-keys")
 async def import_notification_api_keys(
     request_json: ImportApiKeyRequestJson,
-    authorization: Optional[str] = Header(None)
+    authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ):
-    """
-    Import notification API keys from CSV text received in the request body.
-    """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     try:
         csv_content = request_json.content.strip()

--- a/jesse/controllers/live_controller.py
+++ b/jesse/controllers/live_controller.py
@@ -1,8 +1,8 @@
+from jesse.services.auth import require_auth
 from typing import Optional
-from fastapi import APIRouter, Header, Body
+from fastapi import APIRouter, Header, Body, Depends
 from fastapi.responses import JSONResponse
 
-from jesse.services import auth as authenticator
 from jesse.services.multiprocessing import process_manager
 from jesse.services.web import (
     LiveRequestJson, 
@@ -24,12 +24,11 @@ router = APIRouter(prefix="/live", tags=["Live Trading"])
 
 
 @router.post("")
-def live(request_json: LiveRequestJson, authorization: Optional[str] = Header(None)) -> JSONResponse:
+def live(request_json: LiveRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Start live trading
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     jh.validate_cwd()
 
@@ -72,12 +71,11 @@ def live(request_json: LiveRequestJson, authorization: Optional[str] = Header(No
 
 
 @router.post("/cancel")
-def cancel_live(request_json: LiveCancelRequestJson, authorization: Optional[str] = Header(None)):
+def cancel_live(request_json: LiveCancelRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Cancel live trading
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     process_manager.cancel_process(request_json.id)
 
@@ -85,12 +83,11 @@ def cancel_live(request_json: LiveCancelRequestJson, authorization: Optional[str
 
 
 @router.post('/logs')
-def get_logs(json_request: GetLogsRequestJson, authorization: Optional[str] = Header(None)) -> JSONResponse:
+def get_logs(json_request: GetLogsRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Get logs for a live trading session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     arr = gl(json_request.id, json_request.type, json_request.start_time)
 
@@ -101,12 +98,11 @@ def get_logs(json_request: GetLogsRequestJson, authorization: Optional[str] = He
 
 
 @router.post('/orders')
-def get_orders(json_request: GetOrdersRequestJson, authorization: Optional[str] = Header(None)) -> JSONResponse:
+def get_orders(json_request: GetOrdersRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Get orders for a live trading session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     arr = go(json_request.session_id)
 
@@ -119,13 +115,12 @@ def get_orders(json_request: GetOrdersRequestJson, authorization: Optional[str] 
 @router.post("/sessions")
 def get_live_sessions(
     request_json: GetLiveSessionsRequestJson = Body(default=GetLiveSessionsRequestJson()),
-    authorization: Optional[str] = Header(None)
+    authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ):
     """
     Get a list of live sessions sorted by most recently updated with pagination
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     # Get sessions from the database with pagination and filters
     sessions = live_session_repository.get_live_sessions(
@@ -147,12 +142,11 @@ def get_live_sessions(
 
 
 @router.post("/sessions/{session_id}")
-def get_live_session_by_id(session_id: str, authorization: Optional[str] = Header(None)):
+def get_live_session_by_id(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get a single live session by ID
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     # Get the session from the database
     session = live_session_repository.get_live_session_by_id(session_id)
@@ -171,12 +165,11 @@ def get_live_session_by_id(session_id: str, authorization: Optional[str] = Heade
 
 
 @router.post("/sessions/{session_id}/remove")
-def remove_live_session(session_id: str, authorization: Optional[str] = Header(None)):
+def remove_live_session(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Remove a live session from the database
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     session = live_session_repository.get_live_session_by_id(session_id)
 
@@ -202,13 +195,12 @@ def remove_live_session(session_id: str, authorization: Optional[str] = Header(N
 def update_session_notes(
     session_id: str,
     request_json: UpdateLiveSessionNotesRequestJson,
-    authorization: Optional[str] = Header(None)
+    authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ):
     """
     Update the notes (title, description, strategy_codes) of a live session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     session = live_session_repository.get_live_session_by_id(session_id)
 
@@ -230,12 +222,11 @@ def update_session_notes(
 
 
 @router.post("/update-state")
-def update_state(request_json: UpdateLiveSessionStateRequestJson, authorization: Optional[str] = Header(None)):
+def update_state(request_json: UpdateLiveSessionStateRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Upsert live session state (creates draft if doesn't exist, updates if exists)
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     live_session_repository.upsert_live_session_state(request_json.id, request_json.state)
 
@@ -245,12 +236,11 @@ def update_state(request_json: UpdateLiveSessionStateRequestJson, authorization:
 
 
 @router.post("/purge-sessions")
-def purge_sessions(request_json: dict = Body(...), authorization: Optional[str] = Header(None)):
+def purge_sessions(request_json: dict = Body(...), authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Purge live sessions older than specified days
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     days_old = request_json.get('days_old', None)
 
@@ -269,13 +259,12 @@ def get_equity_curve(
     to_ms: Optional[int] = None,
     timeframe: str = 'auto',
     max_points: int = 1000,
-    authorization: Optional[str] = Header(None)
+    authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ) -> JSONResponse:
     """
     Get equity curve for a live session with downsampling
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     from jesse.repositories import live_equity_repository
 

--- a/jesse/controllers/lsp_controller.py
+++ b/jesse/controllers/lsp_controller.py
@@ -1,16 +1,15 @@
+from jesse.services.auth import require_auth
 from typing import Optional
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Header, Depends
 from fastapi.responses import JSONResponse
 from jesse.helpers import get_os
-from jesse.services import auth as authenticator
 from jesse.services.lsp import LSP_DEFAULT_PORT
 
 router = APIRouter(prefix='/lsp-config', tags=['LSP Configuration'])
 
 @router.get("")
-def get_lsp_config(authorization: Optional[str] = Header(None))->JSONResponse:
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
+def get_lsp_config(authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth))->JSONResponse:
 
     from jesse.services.env import ENV_VALUES
 

--- a/jesse/controllers/monte_carlo_controller.py
+++ b/jesse/controllers/monte_carlo_controller.py
@@ -1,9 +1,9 @@
-from fastapi import APIRouter, Header, Request
+from jesse.services.auth import require_auth
+from fastapi import APIRouter, Header, Request, Depends
 from typing import Optional
 from fastapi.responses import JSONResponse
 import json
 
-from jesse.services import auth as authenticator
 from jesse.services.multiprocessing import process_manager
 from jesse.services.web import (
     MonteCarloRequestJson,
@@ -32,12 +32,11 @@ router = APIRouter(prefix="/monte-carlo", tags=["Monte Carlo"])
 
 
 @router.post("")
-async def monte_carlo(request: Request, request_json: MonteCarloRequestJson, authorization: Optional[str] = Header(None)):
+async def monte_carlo(request: Request, request_json: MonteCarloRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Start a Monte Carlo simulation
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     jh.validate_cwd()
 
@@ -106,12 +105,11 @@ async def monte_carlo(request: Request, request_json: MonteCarloRequestJson, aut
 
 
 @router.post("/cancel")
-def cancel_monte_carlo(request_json: CancelMonteCarloRequestJson, authorization: Optional[str] = Header(None)):
+def cancel_monte_carlo(request_json: CancelMonteCarloRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Cancel a Monte Carlo simulation
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     process_manager.cancel_process(request_json.id)
 
@@ -122,12 +120,11 @@ def cancel_monte_carlo(request_json: CancelMonteCarloRequestJson, authorization:
 
 
 @router.post("/terminate")
-def terminate_monte_carlo(request_json: TerminateMonteCarloRequestJson, authorization: Optional[str] = Header(None)):
+def terminate_monte_carlo(request_json: TerminateMonteCarloRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Terminate a Monte Carlo simulation
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     # First update the status to 'terminated'
     update_monte_carlo_session_status(request_json.id, 'terminated')
@@ -142,12 +139,11 @@ def terminate_monte_carlo(request_json: TerminateMonteCarloRequestJson, authoriz
 
 
 @router.post("/resume")
-async def resume_monte_carlo(request_json: MonteCarloRequestJson, authorization: Optional[str] = Header(None)):
+async def resume_monte_carlo(request_json: MonteCarloRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Resume a Monte Carlo simulation
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     jh.validate_cwd()
 
@@ -194,12 +190,11 @@ async def resume_monte_carlo(request_json: MonteCarloRequestJson, authorization:
 
 
 @router.post("/sessions")
-def get_monte_carlo_sessions_endpoint(request_json: GetMonteCarloSessionsRequestJson = GetMonteCarloSessionsRequestJson(), authorization: Optional[str] = Header(None)):
+def get_monte_carlo_sessions_endpoint(request_json: GetMonteCarloSessionsRequestJson = GetMonteCarloSessionsRequestJson(), authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get a list of Monte Carlo sessions sorted by most recently updated with pagination and filters
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     # Get sessions from the database with pagination and filters
     sessions = get_monte_carlo_sessions(
@@ -220,12 +215,11 @@ def get_monte_carlo_sessions_endpoint(request_json: GetMonteCarloSessionsRequest
 
 
 @router.post("/sessions/{session_id}")
-def get_monte_carlo_session_by_id_endpoint(session_id: str, authorization: Optional[str] = Header(None)):
+def get_monte_carlo_session_by_id_endpoint(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get a single Monte Carlo session by ID
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     # Get the session from the database
     session = get_monte_carlo_session_by_id(session_id)
@@ -246,12 +240,11 @@ def get_monte_carlo_session_by_id_endpoint(session_id: str, authorization: Optio
 
 
 @router.post("/sessions/{session_id}/equity-curves")
-def get_monte_carlo_equity_curves(session_id: str, authorization: Optional[str] = Header(None)):
+def get_monte_carlo_equity_curves(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get equity curve data for a Monte Carlo session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     session = get_monte_carlo_session_by_id(session_id)
     
@@ -326,13 +319,12 @@ def get_monte_carlo_equity_curves(session_id: str, authorization: Optional[str] 
 @router.post("/update-state")
 def update_session_state(
     request_json: UpdateMonteCarloSessionStateRequestJson,
-    authorization: Optional[str] = Header(None)
+    authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ):
     """
     Update the state of a Monte Carlo session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     update_monte_carlo_session_state(request_json.id, request_json.state)
 
@@ -342,12 +334,11 @@ def update_session_state(
 
 
 @router.post("/sessions/{session_id}/remove")
-def remove_monte_carlo_session(session_id: str, authorization: Optional[str] = Header(None)):
+def remove_monte_carlo_session(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Remove a Monte Carlo session from the database
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     session = get_monte_carlo_session_by_id(session_id)
 
@@ -370,12 +361,11 @@ def remove_monte_carlo_session(session_id: str, authorization: Optional[str] = H
 
 
 @router.post("/sessions/{session_id}/notes")
-def update_session_notes(session_id: str, request_json: UpdateMonteCarloSessionNotesRequestJson, authorization: Optional[str] = Header(None)):
+def update_session_notes(session_id: str, request_json: UpdateMonteCarloSessionNotesRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Update the notes (title, description, strategy_codes) of a Monte Carlo session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     session = get_monte_carlo_session_by_id(session_id)
 
@@ -392,12 +382,11 @@ def update_session_notes(session_id: str, request_json: UpdateMonteCarloSessionN
 
 
 @router.post("/sessions/{session_id}/strategy-code")
-def get_session_strategy_code(session_id: str, authorization: Optional[str] = Header(None)):
+def get_session_strategy_code(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get the strategy code for a Monte Carlo session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
     
     session = get_monte_carlo_session_by_id(session_id)
     if not session:
@@ -411,12 +400,11 @@ def get_session_strategy_code(session_id: str, authorization: Optional[str] = He
 
 
 @router.post("/sessions/{session_id}/logs")
-def get_session_logs(session_id: str, authorization: Optional[str] = Header(None)):
+def get_session_logs(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get the logs for a Monte Carlo session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
         
     from jesse.modes import data_provider
 
@@ -433,12 +421,11 @@ def get_session_logs(session_id: str, authorization: Optional[str] = Header(None
     
     
 @router.post("/purge-sessions")
-def purge_sessions(request_json: dict, authorization: Optional[str] = Header(None)):
+def purge_sessions(request_json: dict, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Purge Monte Carlo sessions older than specified days
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
     
     days_old = request_json.get('days_old', None)
     
@@ -451,12 +438,11 @@ def purge_sessions(request_json: dict, authorization: Optional[str] = Header(Non
 
 
 @router.get("/running-session")
-def get_running_session(authorization: Optional[str] = Header(None)):
+def get_running_session(authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get the running session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     return JSONResponse({
         'session_id': get_running_monte_carlo_session_id()

--- a/jesse/controllers/notification_controller.py
+++ b/jesse/controllers/notification_controller.py
@@ -1,20 +1,19 @@
+from jesse.services.auth import require_auth
 from typing import Optional
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Header, Depends
 from fastapi.responses import JSONResponse
 
-from jesse.services import auth as authenticator
 from jesse.services.web import StoreNotificationApiKeyRequestJson, DeleteNotificationApiKeyRequestJson
 
 router = APIRouter(prefix="/notification", tags=["Notification"])
 
 
 @router.get("/api-keys")
-def get_notification_api_keys(authorization: Optional[str] = Header(None)) -> JSONResponse:
+def get_notification_api_keys(authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Get all notification API keys
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     from jesse.modes.notification_api_keys import get_notification_api_keys
 
@@ -24,13 +23,12 @@ def get_notification_api_keys(authorization: Optional[str] = Header(None)) -> JS
 @router.post("/api-keys/store")
 def store_notification_api_keys(
         json_request: StoreNotificationApiKeyRequestJson,
-        authorization: Optional[str] = Header(None)
+        authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ) -> JSONResponse:
     """
     Store a new notification API key
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     from jesse.modes.notification_api_keys import store_notification_api_keys
 
@@ -42,13 +40,12 @@ def store_notification_api_keys(
 @router.post("/api-keys/delete")
 def delete_notification_api_keys(
         json_request: DeleteNotificationApiKeyRequestJson,
-        authorization: Optional[str] = Header(None)
+        authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ) -> JSONResponse:
     """
     Delete a notification API key
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     from jesse.modes.notification_api_keys import delete_notification_api_keys
 

--- a/jesse/controllers/optimization_controller.py
+++ b/jesse/controllers/optimization_controller.py
@@ -1,10 +1,9 @@
-from fastapi import APIRouter, Header, Query, Body
+from fastapi import APIRouter, Header, Query, Body, Depends
 from typing import Optional, List
 from fastapi.responses import JSONResponse, FileResponse
 from pydantic import BaseModel
 import json
 
-from jesse.services import auth as authenticator
 from jesse.services.multiprocessing import process_manager
 from jesse.services.web import OptimizationRequestJson, CancelRequestJson, UpdateOptimizationSessionStateRequestJson, UpdateOptimizationSessionStatusRequestJson, TerminateOptimizationRequestJson, UpdateOptimizationSessionNotesRequestJson, GetOptimizationSessionsRequestJson
 from jesse import helpers as jh
@@ -12,18 +11,18 @@ from jesse.models.OptimizationSession import get_optimization_sessions as get_se
 from jesse.services.transformers import get_optimization_session, get_optimization_session_for_load_more
 from jesse.models.OptimizationSession import get_optimization_session_by_id as get_optimization_session_by_id_from_db
 from jesse.modes.optimize_mode import run as run_optimization
+from jesse.services.auth import require_auth, require_auth_token
 
 
 router = APIRouter(prefix="/optimization", tags=["Optimization"])
 
 
 @router.post("")
-async def optimization(request_json: OptimizationRequestJson, authorization: Optional[str] = Header(None)):
+async def optimization(request_json: OptimizationRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Start an optimization process
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     jh.validate_cwd()
 
@@ -76,12 +75,11 @@ async def optimization(request_json: OptimizationRequestJson, authorization: Opt
 
 
 @router.post("/rerun")
-async def rerun_optimization(request_json: OptimizationRequestJson, authorization: Optional[str] = Header(None)):
+async def rerun_optimization(request_json: OptimizationRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Start an optimization process
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     jh.validate_cwd()
 
@@ -125,12 +123,11 @@ async def rerun_optimization(request_json: OptimizationRequestJson, authorizatio
 
 
 @router.post("/cancel")
-def cancel_optimization(request_json: CancelRequestJson, authorization: Optional[str] = Header(None)):
+def cancel_optimization(request_json: CancelRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Cancel an optimization process
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     process_manager.cancel_process(request_json.id)
 
@@ -139,12 +136,10 @@ def cancel_optimization(request_json: CancelRequestJson, authorization: Optional
 
 
 @router.get("/download-log")
-def download_optimization_log(token: str = Query(...)):
+def download_optimization_log(token: str = Query(...), _auth: None = Depends(require_auth_token)):
     """
     Download optimization log file
     """
-    if not authenticator.is_valid_token(token):
-        return authenticator.unauthorized_response()
 
     from jesse.modes import data_provider
 
@@ -152,12 +147,11 @@ def download_optimization_log(token: str = Query(...)):
 
 
 @router.post("/sessions")
-def get_optimization_sessions(request_json: GetOptimizationSessionsRequestJson = Body(default=GetOptimizationSessionsRequestJson()), authorization: Optional[str] = Header(None)):
+def get_optimization_sessions(request_json: GetOptimizationSessionsRequestJson = Body(default=GetOptimizationSessionsRequestJson()), authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get a list of optimization sessions sorted by most recently updated with pagination and filtering
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     # Get sessions from the database with pagination and filters
     sessions = get_sessions(
@@ -178,12 +172,11 @@ def get_optimization_sessions(request_json: GetOptimizationSessionsRequestJson =
 
 
 @router.post("/sessions/{session_id}")
-def get_optimization_session_by_id(session_id: str, authorization: Optional[str] = Header(None)):
+def get_optimization_session_by_id(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get a single optimization session by ID
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     # Get the session from the database
     session = get_optimization_session_by_id_from_db(session_id)
@@ -202,12 +195,11 @@ def get_optimization_session_by_id(session_id: str, authorization: Optional[str]
 
 
 @router.post("/update-state")
-def update_session_state(request_json: UpdateOptimizationSessionStateRequestJson, authorization: Optional[str] = Header(None)):
+def update_session_state(request_json: UpdateOptimizationSessionStateRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Update the state of an optimization session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     update_optimization_session_state(request_json.id, request_json.state)
 
@@ -217,12 +209,11 @@ def update_session_state(request_json: UpdateOptimizationSessionStateRequestJson
 
 
 @router.post("/terminate")
-def terminate_optimization(request_json: TerminateOptimizationRequestJson, authorization: Optional[str] = Header(None)):
+def terminate_optimization(request_json: TerminateOptimizationRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Terminate an optimization process
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     # First update the status to 'terminated'
     update_optimization_session_status(request_json.id, 'terminated')
@@ -234,12 +225,11 @@ def terminate_optimization(request_json: TerminateOptimizationRequestJson, autho
 
 
 @router.post("/resume")
-async def resume_optimization(request_json: OptimizationRequestJson, authorization: Optional[str] = Header(None)):
+async def resume_optimization(request_json: OptimizationRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Resume an optimization process
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     jh.validate_cwd()
 
@@ -284,12 +274,11 @@ async def resume_optimization(request_json: OptimizationRequestJson, authorizati
 
 
 @router.post("/sessions/{session_id}/remove")
-def remove_optimization_session(session_id: str, authorization: Optional[str] = Header(None)):
+def remove_optimization_session(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Remove an optimization session from the database
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     session = get_optimization_session_by_id_from_db(session_id)
 
@@ -312,12 +301,11 @@ def remove_optimization_session(session_id: str, authorization: Optional[str] = 
 
 
 @router.post("/sessions/{session_id}/notes")
-def update_session_notes(session_id: str, request_json: UpdateOptimizationSessionNotesRequestJson, authorization: Optional[str] = Header(None)):
+def update_session_notes(session_id: str, request_json: UpdateOptimizationSessionNotesRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Update the notes (title, description, strategy_codes) of an optimization session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     session = get_optimization_session_by_id_from_db(session_id)
 
@@ -334,12 +322,11 @@ def update_session_notes(session_id: str, request_json: UpdateOptimizationSessio
 
 
 @router.post("/sessions/{session_id}/get-notes")
-def get_session_notes(session_id: str, authorization: Optional[str] = Header(None)):
+def get_session_notes(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get the notes of an optimization session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
     
     session = get_optimization_session_by_id_from_db(session_id)
 
@@ -355,12 +342,11 @@ def get_session_notes(session_id: str, authorization: Optional[str] = Header(Non
     
 
 @router.post("/sessions/{session_id}/strategy-codes")
-def get_session_strategy_codes(session_id: str, authorization: Optional[str] = Header(None)):
+def get_session_strategy_codes(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get the strategy codes of an optimization session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
     
     session = get_optimization_session_by_id_from_db(session_id)
 
@@ -374,12 +360,11 @@ def get_session_strategy_codes(session_id: str, authorization: Optional[str] = H
     })
 
 @router.post("/sessions/{session_id}/logs")
-def get_session_logs(session_id: str, authorization: Optional[str] = Header(None)):
+def get_session_logs(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get the logs for an optimization session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     from jesse.modes import data_provider
 
@@ -396,12 +381,11 @@ def get_session_logs(session_id: str, authorization: Optional[str] = Header(None
 
 
 @router.post("/purge-sessions")
-def purge_sessions(request_json: dict = Body(...), authorization: Optional[str] = Header(None)):
+def purge_sessions(request_json: dict = Body(...), authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Purge optimization sessions older than specified days
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     days_old = request_json.get('days_old', None)
 
@@ -414,12 +398,11 @@ def purge_sessions(request_json: dict = Body(...), authorization: Optional[str] 
 
 
 @router.get("/running-session")
-def get_running_session(authorization: Optional[str] = Header(None)):
+def get_running_session(authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get the running session
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     return JSONResponse({
         'session_id': get_running_optimization_session_id()

--- a/jesse/controllers/order_controller.py
+++ b/jesse/controllers/order_controller.py
@@ -1,8 +1,8 @@
+from jesse.services.auth import require_auth
 from typing import Optional
-from fastapi import APIRouter, Header, Body
+from fastapi import APIRouter, Header, Body, Depends
 from fastapi.responses import JSONResponse
 
-from jesse.services import auth as authenticator
 from jesse.repositories import order_repository
 from jesse.services.transformers import get_order_details
 from jesse.models.Order import Order
@@ -12,9 +12,8 @@ router = APIRouter(prefix="/orders", tags=["Orders"])
 
 
 @router.get("/{order_id}")
-def get_order_by_id(order_id: str, authorization: Optional[str] = Header(None)) -> JSONResponse:
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
+def get_order_by_id(order_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
 
     try:
         # Fetch order by ID
@@ -44,10 +43,9 @@ def get_order_by_id(order_id: str, authorization: Optional[str] = Header(None)) 
 @router.post("/live-history")
 def get_orders_live_history(
     request_json: GetOrdersHistoryRequestJson = Body(...),
-    authorization: Optional[str] = Header(None)
+    authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ) -> JSONResponse:
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     try:
         # Fetch orders with filters

--- a/jesse/controllers/significance_test_controller.py
+++ b/jesse/controllers/significance_test_controller.py
@@ -1,8 +1,9 @@
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Header, Query, Depends
 from typing import Optional
 from fastapi.responses import JSONResponse, FileResponse
 
-from jesse.services import auth as authenticator
+from jesse.services.auth import require_auth, require_auth_any
+
 from jesse.services.multiprocessing import process_manager
 from jesse.services.web import (
     SignificanceTestRequestJson,
@@ -37,9 +38,8 @@ router = APIRouter(prefix="/significance-test", tags=["Significance Test"])
 async def significance_test(
     request_json: SignificanceTestRequestJson,
     authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth),
 ):
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     jh.validate_cwd()
 
@@ -92,9 +92,8 @@ async def significance_test(
 def cancel_significance_test(
     request_json: CancelSignificanceTestRequestJson,
     authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth),
 ):
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     process_manager.cancel_process(request_json.id)
     return JSONResponse(
@@ -107,9 +106,8 @@ def cancel_significance_test(
 def terminate_significance_test(
     request_json: TerminateSignificanceTestRequestJson,
     authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth),
 ):
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     update_significance_test_session_status(request_json.id, 'terminated')
     process_manager.cancel_process(request_json.id)
@@ -123,9 +121,8 @@ def terminate_significance_test(
 def update_state(
     request_json: UpdateSignificanceTestSessionStateRequestJson,
     authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth),
 ):
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     update_significance_test_session_state(request_json.id, request_json.state)
     return JSONResponse({'message': 'Session state updated successfully'})
@@ -135,9 +132,8 @@ def update_state(
 def list_sessions(
     request_json: GetSignificanceTestSessionsRequestJson = GetSignificanceTestSessionsRequestJson(),
     authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth),
 ):
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     sessions = get_significance_test_sessions(
         limit=request_json.limit,
@@ -151,9 +147,8 @@ def list_sessions(
 
 
 @router.post("/sessions/{session_id}")
-def get_session(session_id: str, authorization: Optional[str] = Header(None)):
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
+def get_session(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
 
     session = get_significance_test_session_by_id(session_id)
     if not session:
@@ -165,11 +160,9 @@ def get_session(session_id: str, authorization: Optional[str] = Header(None)):
 
 
 @router.get("/sessions/{session_id}/chart")
-def get_chart(session_id: str, token: Optional[str] = None, authorization: Optional[str] = Header(None)):
+def get_chart(session_id: str, token: Optional[str] = None, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth_any)):
     # Support token via query param (for <img> src) or Authorization header
-    effective_auth = token or authorization
-    if not authenticator.is_valid_token(effective_auth):
-        return authenticator.unauthorized_response()
 
     session = get_significance_test_session_by_id(session_id)
     if not session:
@@ -185,9 +178,8 @@ def get_chart(session_id: str, token: Optional[str] = None, authorization: Optio
 
 
 @router.post("/sessions/{session_id}/remove")
-def remove_session(session_id: str, authorization: Optional[str] = Header(None)):
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
+def remove_session(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
 
     session = get_significance_test_session_by_id(session_id)
     if not session:
@@ -205,9 +197,8 @@ def update_notes(
     session_id: str,
     request_json: UpdateSignificanceTestSessionNotesRequestJson,
     authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth),
 ):
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     session = get_significance_test_session_by_id(session_id)
     if not session:
@@ -223,9 +214,8 @@ def update_notes(
 
 
 @router.post("/sessions/{session_id}/strategy-code")
-def get_strategy_code(session_id: str, authorization: Optional[str] = Header(None)):
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
+def get_strategy_code(session_id: str, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
 
     import json
     session = get_significance_test_session_by_id(session_id)
@@ -239,9 +229,8 @@ def get_strategy_code(session_id: str, authorization: Optional[str] = Header(Non
 
 
 @router.post("/purge-sessions")
-def purge_sessions(request_json: dict, authorization: Optional[str] = Header(None)):
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
+def purge_sessions(request_json: dict, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
 
     days_old = request_json.get('days_old', None)
     deleted_count = purge_significance_test_sessions(days_old)
@@ -252,8 +241,7 @@ def purge_sessions(request_json: dict, authorization: Optional[str] = Header(Non
 
 
 @router.get("/running-session")
-def get_running_session(authorization: Optional[str] = Header(None)):
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
+def get_running_session(authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
 
     return JSONResponse({'session_id': get_running_significance_test_session_id()})

--- a/jesse/controllers/strategy_controller.py
+++ b/jesse/controllers/strategy_controller.py
@@ -1,10 +1,10 @@
+from jesse.services.auth import require_auth
 from typing import Optional
-from fastapi import APIRouter, Header, Query
+from fastapi import APIRouter, Header, Query, Depends
 from fastapi.responses import JSONResponse
 import requests
 import re
 
-from jesse.services import auth as authenticator
 from jesse.services.web import (
     NewStrategyRequestJson,
     GetStrategyRequestJson,
@@ -20,24 +20,22 @@ router = APIRouter(prefix="/strategy", tags=["Strategy"])
 
 
 @router.post("/make")
-def make_strategy(json_request: NewStrategyRequestJson, authorization: Optional[str] = Header(None)) -> JSONResponse:
+def make_strategy(json_request: NewStrategyRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Create a new strategy
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     from jesse.services import strategy_handler
     return strategy_handler.generate(json_request.name)
 
 
 @router.get("/all")
-def get_strategies(authorization: Optional[str] = Header(None)) -> JSONResponse:
+def get_strategies(authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Get all strategies
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     from jesse.services import strategy_handler
     return strategy_handler.get_strategies()
@@ -46,13 +44,12 @@ def get_strategies(authorization: Optional[str] = Header(None)) -> JSONResponse:
 @router.post("/get")
 def get_strategy(
         json_request: GetStrategyRequestJson,
-        authorization: Optional[str] = Header(None)
+        authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ) -> JSONResponse:
     """
     Get a specific strategy
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     from jesse.services import strategy_handler
     return strategy_handler.get_strategy(json_request.name)
@@ -61,13 +58,12 @@ def get_strategy(
 @router.post("/save")
 def save_strategy(
         json_request: SaveStrategyRequestJson,
-        authorization: Optional[str] = Header(None)
+        authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ) -> JSONResponse:
     """
     Save a strategy
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     from jesse.services import strategy_handler
     return strategy_handler.save_strategy(json_request.name, json_request.content)
@@ -76,13 +72,12 @@ def save_strategy(
 @router.post("/fork")
 def fork_strategy(
         json_request: ForkStrategyRequestJson,
-        authorization: Optional[str] = Header(None)
+        authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ) -> JSONResponse:
     """
     Fork a strategy under a new name
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     from jesse.services import strategy_handler
     return strategy_handler.fork_strategy(json_request.new_name, json_request.content)
@@ -91,13 +86,12 @@ def fork_strategy(
 @router.post("/delete")
 def delete_strategy(
         json_request: DeleteStrategyRequestJson,
-        authorization: Optional[str] = Header(None)
+        authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ) -> JSONResponse:
     """
     Delete a strategy
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     from jesse.services import strategy_handler
     return strategy_handler.delete_strategy(json_request.name)
@@ -110,13 +104,12 @@ async def index_jesse_trade_strategies(
         submitted_after: Optional[str] = Query(None),
         submitted_before: Optional[str] = Query(None),
         authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth),
         jesse_trade_token: Optional[str] = Header(None, alias="X-Jesse-Trade-Token")
 ) -> JSONResponse:
     """
     Browse strategies from jesse.trade
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     try:
         headers = {}
@@ -152,13 +145,12 @@ async def index_jesse_trade_strategies(
 
 @router.get("/periods")
 async def get_jesse_trade_periods(
-        authorization: Optional[str] = Header(None)
+        authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)
 ) -> JSONResponse:
     """
     Get available trading periods from jesse.trade
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     try:
         response = requests.get(
@@ -184,13 +176,12 @@ async def get_jesse_trade_periods(
 async def get_jesse_trade_strategy(
         slug: str,
         authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth),
         jesse_trade_token: Optional[str] = Header(None, alias="X-Jesse-Trade-Token")
 ) -> JSONResponse:
     """
     Get a specific strategy from jesse.trade
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     try:
         headers = {}
@@ -224,13 +215,12 @@ async def get_jesse_trade_strategy_metrics(
         symbol: str = Query(...),
         timeframe: str = Query(...),
         authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth),
         jesse_trade_token: Optional[str] = Header(None, alias="X-Jesse-Trade-Token")
 ) -> JSONResponse:
     """
     Get metrics for a specific strategy from jesse.trade
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     try:
         headers = {}
@@ -262,13 +252,12 @@ async def get_jesse_trade_strategy_metrics(
 async def import_strategy(
         json_request: ImportStrategyRequestJson,
         authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth),
         jesse_trade_token: Optional[str] = Header(None, alias="X-Jesse-Trade-Token")
 ) -> JSONResponse:
     """
     Import a strategy from jesse.trade
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     try:
         # Fetch the strategy from jesse.trade

--- a/jesse/controllers/system_controller.py
+++ b/jesse/controllers/system_controller.py
@@ -1,11 +1,10 @@
 from typing import Optional
-from fastapi import APIRouter, Header
+from fastapi import APIRouter, Header, Depends
 from fastapi.responses import JSONResponse
 import psutil
 import os
 import requests
 
-from jesse.services import auth as authenticator
 from jesse.services.web import FeedbackRequestJson, ReportExceptionRequestJson, HelpSearchRequestJson
 from jesse.services.multiprocessing import process_manager
 from jesse.services import jesse_trade
@@ -20,24 +19,22 @@ router = APIRouter(prefix="/system", tags=["System"])
 
 
 @router.post("/feedback")
-def feedback(json_request: FeedbackRequestJson, authorization: Optional[str] = Header(None)) -> JSONResponse:
+def feedback(json_request: FeedbackRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Send feedback to the Jesse team
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     return jesse_trade.feedback(json_request.description, json_request.email)
 
 
 @router.post("/report-exception")
 def report_exception(json_request: ReportExceptionRequestJson,
-                     authorization: Optional[str] = Header(None)) -> JSONResponse:
+                     authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Report an exception to the Jesse team
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     return jesse_trade.report_exception(
         json_request.description,
@@ -51,12 +48,11 @@ def report_exception(json_request: ReportExceptionRequestJson,
 
 
 @router.post("/general-info")
-def general_info(authorization: Optional[str] = Header(None)) -> JSONResponse:
+def general_info(authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Get general information about the system
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     try:
         data = get_general_info(has_live=jh.has_live_trade_plugin())
@@ -73,12 +69,11 @@ def general_info(authorization: Optional[str] = Header(None)) -> JSONResponse:
 
 
 @router.post("/active-workers")
-def active_workers(authorization: Optional[str] = Header(None)) -> JSONResponse:
+def active_workers(authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Get a list of active workers
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     return JSONResponse({
         'data': list(process_manager.active_workers)
@@ -86,12 +81,11 @@ def active_workers(authorization: Optional[str] = Header(None)) -> JSONResponse:
 
 
 @router.post("/help-search")
-def help_search(json_request: HelpSearchRequestJson, authorization: Optional[str] = Header(None)) -> JSONResponse:
+def help_search(json_request: HelpSearchRequestJson, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Proxy endpoint for help center search to avoid CORS issues
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
     
     try:
         url = f'{JESSE_API_URL}/help/search?item={json_request.query}'
@@ -120,12 +114,11 @@ def help_search(json_request: HelpSearchRequestJson, authorization: Optional[str
 
 
 @router.get("/system-info")
-def system_info(authorization: Optional[str] = Header(None)) -> JSONResponse:
+def system_info(authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Get system info (CPU, RAM, version, etc)
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     strategies_path = os.getcwd() + "/strategies/"
     try:
@@ -148,12 +141,11 @@ def system_info(authorization: Optional[str] = Header(None)) -> JSONResponse:
 
 
 @router.get("/user-activity")
-def user_activity(authorization: Optional[str] = Header(None)) -> JSONResponse:
+def user_activity(authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)) -> JSONResponse:
     """
     Get user activity stats (backtests, optimizations, etc)
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
 
     current_timestamp = jh.now_to_timestamp(True)
     day_ago = current_timestamp - (24 * 60 * 60 * 1000)

--- a/jesse/controllers/tabs_controller.py
+++ b/jesse/controllers/tabs_controller.py
@@ -1,8 +1,8 @@
-from fastapi import APIRouter, Header
+from jesse.services.auth import require_auth
+from fastapi import APIRouter, Header, Depends
 from pydantic import BaseModel
 from typing import List, Optional
 from jesse.repositories import open_tab_repository
-from jesse.services import auth as authenticator
 
 
 router = APIRouter()
@@ -32,50 +32,46 @@ class TabsResponse(BaseModel):
 
 
 @router.post('/tabs/list', response_model=TabsResponse)
-async def list_tabs(req: TabsListRequest, authorization: Optional[str] = Header(None)):
+async def list_tabs(req: TabsListRequest, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Get ordered list of open tab session IDs for a module
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
     
     session_ids = open_tab_repository.get_open_tab_session_ids(req.module)
     return TabsResponse(ids=session_ids)
 
 
 @router.post('/tabs/add', response_model=TabsResponse)
-async def add_tab(req: TabsAddRequest, authorization: Optional[str] = Header(None)):
+async def add_tab(req: TabsAddRequest, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Add a new tab (or update if exists). Returns ordered list.
     For singleton modules, ensures only 1 tab exists.
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
     
     session_ids = open_tab_repository.add_open_tab(req.module, req.id)
     return TabsResponse(ids=session_ids)
 
 
 @router.post('/tabs/remove', response_model=TabsResponse)
-async def remove_tab(req: TabsRemoveRequest, authorization: Optional[str] = Header(None)):
+async def remove_tab(req: TabsRemoveRequest, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Remove a tab and reorder remaining tabs. Returns ordered list.
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
     
     session_ids = open_tab_repository.remove_open_tab(req.module, req.id)
     return TabsResponse(ids=session_ids)
 
 
 @router.post('/tabs/reorder', response_model=TabsResponse)
-async def reorder_tabs(req: TabsReorderRequest, authorization: Optional[str] = Header(None)):
+async def reorder_tabs(req: TabsReorderRequest, authorization: Optional[str] = Header(None),
+    _auth: None = Depends(require_auth)):
     """
     Reorder tabs to match the provided session_ids list.
     For singleton modules, ensures only 1 tab exists.
     """
-    if not authenticator.is_valid_token(authorization):
-        return authenticator.unauthorized_response()
     
     session_ids = open_tab_repository.reorder_open_tabs(req.module, req.ids)
     return TabsResponse(ids=session_ids)

--- a/jesse/services/auth.py
+++ b/jesse/services/auth.py
@@ -1,6 +1,28 @@
 from hashlib import sha256
+from typing import Optional
+from fastapi import Header, Query, Depends
 from fastapi.responses import JSONResponse
+from fastapi import HTTPException
 from jesse.services.env import ENV_VALUES
+
+
+def require_auth(authorization: Optional[str] = Header(None)) -> None:
+    if not is_valid_token(authorization):
+        raise HTTPException(status_code=401, detail="Invalid password")
+
+
+def require_auth_token(token: Optional[str] = Query(None)) -> None:
+    if not is_valid_token(token):
+        raise HTTPException(status_code=401, detail="Invalid password")
+
+
+def require_auth_any(
+    token: Optional[str] = Query(None),
+    authorization: Optional[str] = Header(None),
+) -> None:
+    effective = token or authorization
+    if not is_valid_token(effective):
+        raise HTTPException(status_code=401, detail="Invalid password")
 
 
 def password_to_token(password: str) -> JSONResponse:


### PR DESCRIPTION
## Summary

Replace the repetitive `if not authenticator.is_valid_token(authorization): return authenticator.unauthorized_response()` pattern across **16 controller files** (118 occurrences) with a single `require_auth` FastAPI `Depends()` dependency.

## Changes

- **`jesse/services/auth.py`**: Add three auth dependencies:
  - `require_auth` — validates `Authorization` header (used by 105 endpoints)
  - `require_auth_token` — validates `token` query param (used by 4 endpoints: backtest logs, download-log, optimization download-log, file download)
  - `require_auth_any` — validates either query `token` OR `Authorization` header (used by 3 endpoints: charts-image, significance chart)
- **16 controllers**: Apply `Depends(require_auth)` / `Depends(require_auth_token)` / `Depends(require_auth_any)` to all endpoints that had manual auth checks
- **`file_controller.py`**: Replace stale `authenticator.unauthorized_response()` with proper `unauthorized_response` import

### Files Modified (18 total)
`jesse/services/auth.py`, `jesse/controllers/{backtest,candles,closed_trade,config,exchange,file,live,lsp,monte_carlo,notification,optimization,order,significance_test,strategy,tabs}_controller.py`

## Expected Impact
- **-109 net lines** of boilerplate auth code removed
- Eliminates a class of bugs where new endpoints ship without auth
- Consistent 401 error handling via `HTTPException` instead of mixed `JSONResponse`/`HTTPException`

## Tradeoffs
- `auth_controller.py` (login endpoint) and `websocket_controller.py` (WebSocket with query param) are intentionally excluded
- `require_auth_any` evaluates `token or authorization` which means query param takes precedence (matches original `effective_auth = token or authorization` behavior)