### PR TITLE
Add MCP support for optimization mode

### DIFF
--- a/jesse/mcp/resources/optimization.md
+++ b/jesse/mcp/resources/optimization.md
@@ -1,0 +1,222 @@
+# Hyperparameter Optimization via MCP
+
+Optimization tunes a strategy's `hyperparameters()` to maximize an objective
+(Sharpe by default) on a **training** window, and reports each candidate's
+**out-of-sample** performance on a separate **testing** window. The train/test
+split is the whole point: it lets you tell a genuinely good parameter set apart
+from one that's overfit to the training data.
+
+It answers: "what parameter values work best for this strategy, and do they hold
+up on data they weren't tuned on?"
+
+## Preconditions (read before creating a draft)
+
+1. **The strategy must declare a non-empty `hyperparameters()`** list — that list
+   is what gets optimized. A strategy with no hyperparameters cannot be optimized
+   and the run stops with an `InvalidStrategy` error. Each entry looks like:
+   ```python
+   def hyperparameters(self):
+       return [
+           {'name': 'fast_period', 'type': int, 'min': 5, 'max': 25, 'default': 10},
+           {'name': 'slow_period', 'type': int, 'min': 26, 'max': 60, 'default': 30},
+       ]
+   ```
+   Types: `int`, `float`, or `categorical` (with an `options` list). The strategy
+   reads the chosen values via `self.hp['name']`.
+2. **Candles must exist for BOTH windows** (training and testing), plus ~warm-up
+   candles before each start. Don't pre-check — run it; on a candle shortage the
+   session stops with a clear message telling you exactly what to import, then
+   `import_candles()` and `rerun_optimization()`.
+
+## Key concepts
+
+| Concept | What it means |
+|---|---|
+| **Training window** | `training_start_date` → `training_finish_date`. The in-sample period the optimizer tunes on. |
+| **Testing window** | `testing_start_date` → `testing_finish_date`. The out-of-sample period each candidate is re-evaluated on (not used for tuning). Conventionally `testing_start_date == training_finish_date` (contiguous), but any non-overlapping ranges are fine. |
+| **objective_function** | What to maximize. One of `sharpe` (default), `calmar`, `sortino`, `omega`, `serenity`, `smart sharpe`, `smart sortino`. |
+| **trials** | Trials **per hyperparameter**. Total trials = `n_hyperparameters × trials`. With 2 hyperparameters and `trials=200`, the optimizer runs 400 trials. Lower it (e.g. 20–50) for a quick exploratory run. |
+| **best_candidates** | The ranked top parameter sets, each with training AND testing metrics. |
+
+## Interpreting best_candidates (overfit detection)
+
+Each finished session exposes `best_candidates`, ranked best-first by the
+objective on the training window. The critical read is **training vs testing**:
+
+| Pattern | Verdict |
+|---|---|
+| Strong on training **and** testing holds up close to training | **Trustworthy.** The parameters generalize — this is what you want. |
+| Strong on training, **much weaker / negative on testing** | **Overfit.** Tuned to noise in the training window; don't deploy. |
+| Mediocre on both | No edge from these parameters — the strategy/idea may not work. |
+| Weak on training but strong on testing | Usually luck on the test window; treat with suspicion, prefer consistency. |
+
+Each candidate carries:
+- `rank` (`#1` is best by the training objective), `trial`, `params` (the tuned
+  values), `fitness` (the objective score), `dna` (a compact encoding),
+- `training_metrics` and `testing_metrics` (full metric dicts each),
+- `objective_metric` — a convenient `"<train> / <test>"` summary on the chosen
+  objective.
+
+**Don't just pick rank #1.** Rank is by *training* fitness; the right choice is
+the candidate whose **testing** metrics hold up best relative to its training
+metrics (smallest train→test degradation), among the strong performers.
+
+## Tool reference
+
+### create_optimization_draft()
+Stages a draft you can then run.
+- `exchange` (default `"Binance Perpetual Futures"`)
+- `routes` — JSON string array of route objects
+- `data_routes` — JSON string array (default `"[]"`)
+- `training_start_date`, `training_finish_date` — `YYYY-MM-DD`
+- `testing_start_date`, `testing_finish_date` — `YYYY-MM-DD`
+- `optimal_total` — int, target number of best candidates to surface (default 50)
+- `objective_function` — str (default `"sharpe"`; see list above)
+- `trials` — int, per hyperparameter (default 200)
+- `best_candidates_count` — int (default 20)
+- `warm_up_candles` — int (default 210)
+- `fast_mode` — bool (default True)
+- `cpu_cores` — int (default `cpu_count - 1`, capped at 4)
+- `title`, `description`, `strategy_summary`, `hypothesis`, `rationale` — optional
+  notes metadata; auto-generated if omitted
+
+Returns: `{ "status": "success", "session_id": "<uuid>", ... }`
+
+### update_optimization_draft(session_id, state)
+Replace the whole `state` on an existing draft (read-modify-write).
+
+### update_optimization_notes(session_id, title?, description?, strategy_codes?)
+Update notes — typically to record the chosen parameters and conclusion.
+
+### get_optimization_session(session_id)
+Fetch full details — the primary polling tool.
+```json
+{
+  "data": { "session": {
+    "id": "<uuid>",
+    "status": "running",
+    "completed_trials": 120,
+    "total_trials": 400,
+    "best_candidates": [
+      { "rank": "#1", "trial": "Trial 18",
+        "params": {"fast_period": 12, "slow_period": 35},
+        "fitness": 0.48, "dna": "...",
+        "training_metrics": {"sharpe_ratio": 2.13, "total": 38, ...},
+        "testing_metrics":  {"sharpe_ratio": 1.72, "total": 17, ...},
+        "objective_metric": "2.13 / 1.72" }
+    ],
+    "objective_curve": [...],
+    "exception": null, "traceback": null
+  } },
+  "error": null, "message": "Optimization session retrieved successfully"
+}
+```
+
+### get_optimization_sessions(limit?, offset?, title_search?, status_filter?, date_filter?)
+List sessions (most recent first). `status_filter`: `draft`, `running`, `paused`,
+`finished`, `stopped`, `terminated`.
+
+### get_optimization_logs(session_id)
+Fetch the log file content. Useful when `status == "stopped"` to find the
+underlying error, or to watch trial-by-trial progress on a long run.
+
+### run_optimization(session_id)
+Fire-and-poll. Returns `{ "status": "started", ... }` when the server accepts.
+Then keep checking `get_optimization_session` until a terminal status. See
+"Checking for results" below.
+
+### rerun_optimization(session_id)
+Reset (clears prior trials/best_candidates) and restart an existing session. Use
+this to run a finished/stopped session again — e.g. after importing missing
+candles or editing the strategy. Cancel a running session first.
+
+### cancel_optimization(session_id)
+Cooperative cancel — stops at the next trial checkpoint; completed trials are kept.
+
+### terminate_optimization(session_id)
+Hard stop — marks the session `terminated` and force-kills the worker. Prefer
+`cancel_optimization` unless the worker is stuck.
+
+### purge_optimization_sessions(days_old?)
+Delete old sessions. If `days_old` is omitted, deletes **all** sessions.
+
+## Checking for results
+
+Optimization is the **slowest** of the modes — it runs `n_hyperparameters ×
+trials` backtests, each on both the training and testing windows. Keep checking
+until a terminal status (`finished`, `stopped`, `terminated`); never ask the user
+to drive the loop. Watch `completed_trials / total_trials` for progress and ETA.
+
+Adaptive check schedule (when `status == "running"`):
+
+| Elapsed since fire | Check every |
+|---|---|
+| 0 – 1 min | 5 s |
+| 1 – 5 min | 20 s |
+| 5 – 30 min | 60 s |
+| 30 – 120 min | 2 – 3 min |
+| > 2 h | 5 min |
+
+If `completed_trials > 0`, estimate ETA as
+`elapsed × (total_trials / completed_trials)` and set the next check to roughly
+`min(remaining_eta / 5, max_interval)`.
+
+Status semantics:
+- `running` / `paused` → keep checking
+- `finished` → read `best_candidates`; report the train-vs-test verdict
+- `stopped` → run failed; read `exception` (e.g. missing candles, or the strategy
+  has no hyperparameters) and `get_optimization_logs(sid)`, then report it
+- `terminated` → user-initiated stop; report the partial state, don't retry
+  without the user's say-so
+
+User-facing language: say **"checking for results"** in chat, not "polling".
+
+## Standard workflow
+
+```python
+# 1. Stage the optimization (train then test, contiguous windows)
+draft = create_optimization_draft(
+    exchange="Binance Perpetual Futures",
+    routes='[{"exchange":"Binance Perpetual Futures","strategy":"MyStrategy","symbol":"BTC-USDT","timeframe":"4h"}]',
+    training_start_date="2023-01-01", training_finish_date="2024-06-01",
+    testing_start_date="2024-06-01",  testing_finish_date="2024-12-01",
+    objective_function="sharpe", trials=100,
+    hypothesis="MyStrategy's EMA periods generalize out-of-sample.",
+)
+sid = draft["session_id"]
+
+# 2. Fire it
+run_optimization(sid)
+
+# 3. Keep checking until terminal (optimization is slow — widen the interval)
+while True:
+    s = get_optimization_session(sid)
+    status = s["data"]["session"]["status"]
+    if status in ("finished", "stopped", "terminated"):
+        break
+    time.sleep(20)
+
+# 4. Pick the candidate that generalizes best (smallest train->test drop)
+session = s["data"]["session"]
+if status == "finished":
+    cands = session["best_candidates"]
+    # report rank #1 plus train-vs-test for the top few; flag overfit candidates
+elif status == "stopped":
+    # read session["exception"] / get_optimization_logs(sid); if missing candles,
+    # import_candles() for both windows (~2 months before each start) then rerun_optimization(sid)
+    ...
+```
+
+## Constraints / common errors
+
+- **Strategy needs `hyperparameters()`** — empty list → `InvalidStrategy`, nothing
+  to optimize.
+- **Candles for BOTH windows** — a shortage stops the session with a message
+  naming both windows; `import_candles()` then `rerun_optimization()`.
+- **`trials` is per-hyperparameter** — total = `n_hyperparameters × trials`. Don't
+  set it huge on a multi-hyperparameter strategy unless you want a very long run.
+- **At least one route is required.**
+- **409 on the main endpoint** — the draft row already exists, which is why
+  `run_optimization` fires via the resume endpoint; you don't normally hit this.
+- **CPU- and time-bound** — far heavier than a single backtest. Use a smaller
+  `trials` and short windows for a quick exploratory pass, then scale up.

--- a/jesse/mcp/tools/__init__.py
+++ b/jesse/mcp/tools/__init__.py
@@ -39,6 +39,7 @@ from jesse.mcp.tools.candles import register_candles_tools
 from jesse.mcp.tools.indicator import register_indicator_tools
 from jesse.mcp.tools.significance_test import register_significance_test_tools
 from jesse.mcp.tools.monte_carlo import register_monte_carlo_tools
+from jesse.mcp.tools.optimization import register_optimization_tools
 
 def register_tools(mcp):
     """
@@ -73,3 +74,6 @@ def register_tools(mcp):
 
     # Monte Carlo simulation tools (robustness analysis of finished strategies)
     register_monte_carlo_tools(mcp)
+
+    # Optimization tools (hyperparameter tuning with train/test split)
+    register_optimization_tools(mcp)

--- a/jesse/mcp/tools/optimization.py
+++ b/jesse/mcp/tools/optimization.py
@@ -1,0 +1,283 @@
+"""
+Jesse Optimization Tools
+
+MCP tools for hyperparameter optimization, mirroring the Monte Carlo tools so the
+agent uses the same draft / run / poll workflow.
+
+Workflow:
+    1. create_optimization_draft(...)  -> returns session_id
+    2. run_optimization(session_id)    -> fires the run, returns immediately
+    3. poll get_optimization_session(session_id) until status == "finished"
+       (or "stopped"/"terminated"); read best_candidates for the tuned params.
+
+Requirements / gotchas:
+    - The strategy MUST define a non-empty hyperparameters() list — otherwise there
+      is nothing to optimize and the run stops with an error.
+    - Candles must exist for BOTH the training and testing windows (plus warm-up
+      before each). If they're missing the session stops with a clear message
+      telling you what to import.
+    - `trials` is PER hyperparameter: total trials = n_hyperparameters * trials.
+    - Optimization is long-running; poll less frequently than a backtest.
+"""
+
+from .services import (
+    create_optimization_draft_service,
+    update_optimization_draft_service,
+    update_optimization_notes_service,
+    get_optimization_session_service,
+    get_optimization_sessions_service,
+    get_optimization_logs_service,
+    run_optimization_service,
+    rerun_optimization_service,
+    cancel_optimization_service,
+    terminate_optimization_service,
+    purge_optimization_sessions_service,
+)
+
+
+def register_optimization_tools(mcp):
+    """Register the optimization tools with the MCP server."""
+
+    @mcp.tool()
+    def create_optimization_draft(
+        exchange: str = "Binance Perpetual Futures",
+        routes: str = '[{"exchange": "Binance Perpetual Futures", "strategy": "ExampleStrategy", "symbol": "BTC-USDT", "timeframe": "4h"}]',
+        data_routes: str = '[]',
+        training_start_date: str = "2021-01-01",
+        training_finish_date: str = "2022-06-01",
+        testing_start_date: str = "2022-06-01",
+        testing_finish_date: str = "2023-01-01",
+        optimal_total: int = 50,
+        objective_function: str = "sharpe",
+        trials: int = 200,
+        best_candidates_count: int = 20,
+        warm_up_candles: int = 210,
+        fast_mode: bool = True,
+        cpu_cores: int = None,
+        title: str = None,
+        description: str = None,
+        strategy_summary: str = None,
+        hypothesis: str = None,
+        rationale: str = None,
+    ) -> dict:
+        """
+        Create a new hyperparameter Optimization draft session.
+
+        Optimization tunes a strategy's hyperparameters() on a TRAINING window and
+        reports out-of-sample performance on a separate TESTING window, so you can
+        spot overfitting (great train metrics + poor test metrics).
+
+        PRECONDITIONS:
+            - The strategy in the route must already exist on disk (create it with
+              create_strategy first) and must define a NON-EMPTY hyperparameters()
+              method — that list is what gets optimized. With no hyperparameters
+              there is nothing to optimize and the run will stop with an error.
+            - Candles must exist for BOTH the training and testing windows (plus
+              ~warm_up_candles before each start). If missing, the run stops with a
+              message telling you exactly what to import; import then rerun.
+
+        Parameters:
+            exchange: Exchange name (default "Binance Perpetual Futures").
+            routes: JSON string array with the trading route(s):
+                [{"exchange": "...", "strategy": "...", "symbol": "...", "timeframe": "..."}]
+            data_routes: JSON string array (default "[]").
+            training_start_date / training_finish_date: YYYY-MM-DD — the in-sample
+                window the optimizer tunes on.
+            testing_start_date / testing_finish_date: YYYY-MM-DD — the out-of-sample
+                window used to report each candidate's generalization. Conventionally
+                testing_start_date == training_finish_date (contiguous), but they can
+                be any non-overlapping ranges.
+            optimal_total: Target number of best candidates to surface (default 50).
+            objective_function: What to maximize. One of: "sharpe" (default),
+                "calmar", "sortino", "omega", "serenity", "smart sharpe",
+                "smart sortino".
+            trials: Trials PER hyperparameter (default 200). Total trials =
+                n_hyperparameters * trials. Lower it (e.g. 20-50) for a quick run.
+            best_candidates_count: How many top candidates to keep (default 20).
+            warm_up_candles: Warm-up candles before each window start (default 210).
+            fast_mode: Faster, slightly less precise simulation (default True).
+            cpu_cores: Worker count. Defaults to (cpu_count - 1, capped at 4).
+            title / description: Optional notes; auto-generated if omitted.
+            strategy_summary / hypothesis / rationale: Optional note context.
+
+        Returns:
+            { "status": "success", "session_id": "<uuid>", "draft_state": {...},
+              "notes": {...}, "dashboard_url": "...", "message": "..." }
+        """
+        return create_optimization_draft_service(
+            exchange=exchange,
+            routes=routes,
+            data_routes=data_routes,
+            training_start_date=training_start_date,
+            training_finish_date=training_finish_date,
+            testing_start_date=testing_start_date,
+            testing_finish_date=testing_finish_date,
+            optimal_total=optimal_total,
+            objective_function=objective_function,
+            trials=trials,
+            best_candidates_count=best_candidates_count,
+            warm_up_candles=warm_up_candles,
+            fast_mode=fast_mode,
+            cpu_cores=cpu_cores,
+            title=title,
+            description=description,
+            strategy_summary=strategy_summary,
+            hypothesis=hypothesis,
+            rationale=rationale,
+        )
+
+    @mcp.tool()
+    def update_optimization_draft(session_id: str, state: str) -> dict:
+        """
+        Replace the full state of an optimization draft.
+
+        Parameters:
+            session_id: UUID of the optimization session.
+            state: JSON string of the complete state object ({"form": {...}, "results": {...}}).
+                Retrieve current state with get_optimization_session, modify, and send back.
+        """
+        return update_optimization_draft_service(session_id, state)
+
+    @mcp.tool()
+    def update_optimization_notes(
+        session_id: str,
+        title: str = None,
+        description: str = None,
+        strategy_codes: str = None,
+    ) -> dict:
+        """
+        Update title / description / strategy-code snapshot on an optimization session.
+
+        Parameters:
+            session_id: UUID of the session.
+            title / description: Optional note fields.
+            strategy_codes: Optional JSON object string mapping "exchange-symbol" to
+                strategy source.
+        """
+        return update_optimization_notes_service(
+            session_id=session_id,
+            title=title,
+            description=description,
+            strategy_codes=strategy_codes,
+        )
+
+    @mcp.tool()
+    def get_optimization_session(session_id: str) -> dict:
+        """
+        Fetch full details of an optimization session — the primary polling tool.
+
+        Returns (shape):
+            {
+              "data": { "session": {
+                  "id": "<uuid>",
+                  "status": "draft|running|paused|finished|stopped|terminated",
+                  "completed_trials": int,
+                  "total_trials": int,            # n_hyperparameters * trials
+                  "best_candidates": [            # populated as trials complete
+                    { "rank": "#1", "trial": "Trial N", "params": {...},
+                      "fitness": float, "dna": "...",
+                      "training_metrics": {...},   # in-sample
+                      "testing_metrics": {...},    # out-of-sample
+                      "objective_metric": "train / test" },
+                    ...
+                  ],
+                  "objective_curve": [...],
+                  "exception": str | null,
+                  "traceback": str | null
+              } },
+              "error": null | str,
+              "message": str
+            }
+
+        Polling: status == "running" → keep polling (every ~20-30s; optimization is
+        slow). status == "finished" → read best_candidates (rank #1 is best by the
+        objective). status == "stopped" → read `exception` (e.g. missing candles, or
+        the strategy has no hyperparameters).
+
+        Interpreting results: compare each candidate's training_metrics vs
+        testing_metrics. A candidate that's strong in training but weak in testing is
+        overfit; prefer candidates that hold up out-of-sample.
+        """
+        return get_optimization_session_service(session_id)
+
+    @mcp.tool()
+    def get_optimization_sessions(
+        limit: int = 50,
+        offset: int = 0,
+        title_search: str = None,
+        status_filter: str = None,
+        date_filter: str = None,
+    ) -> dict:
+        """
+        List optimization sessions (most recent first), with pagination/filtering.
+
+        Parameters:
+            limit (default 50), offset (default 0).
+            title_search: case-insensitive title substring.
+            status_filter: "running" | "paused" | "finished" | "stopped" | "terminated".
+            date_filter: "today" | "this_week" | "this_month" | "this_year".
+        """
+        return get_optimization_sessions_service(
+            limit=limit,
+            offset=offset,
+            title_search=title_search,
+            status_filter=status_filter,
+            date_filter=date_filter,
+        )
+
+    @mcp.tool()
+    def get_optimization_logs(session_id: str) -> dict:
+        """
+        Fetch the raw log file content for an optimization session. Useful for
+        diagnosing a stopped run beyond the `exception` field.
+        """
+        return get_optimization_logs_service(session_id)
+
+    @mcp.tool()
+    def run_optimization(session_id: str) -> dict:
+        """
+        Start a previously created optimization draft and return immediately.
+
+        Fire-and-poll: returns once the server acknowledges. Then poll
+        get_optimization_session(session_id) until status is "finished" (or
+        "stopped"/"terminated"). Optimization is long-running — poll less frequently
+        (every ~20-30s) and watch completed_trials / total_trials.
+
+        Returns: { "status": "started", "session_id": "<uuid>", "message": "..." }
+                 or { "status": "error", "message": "..." }
+        """
+        return run_optimization_service(session_id)
+
+    @mcp.tool()
+    def rerun_optimization(session_id: str) -> dict:
+        """
+        Reset and restart an existing optimization session, clearing its prior
+        trials and results. Use this to run a finished or stopped session again
+        (e.g. after importing missing candles or editing the strategy). Cancel a
+        running session first before rerunning.
+        """
+        return rerun_optimization_service(session_id)
+
+    @mcp.tool()
+    def cancel_optimization(session_id: str) -> dict:
+        """
+        Cooperatively cancel a running optimization. The worker stops at the next
+        trial checkpoint; partial results (completed trials) are preserved.
+        """
+        return cancel_optimization_service(session_id)
+
+    @mcp.tool()
+    def terminate_optimization(session_id: str) -> dict:
+        """
+        Hard-terminate a running optimization (marks it 'terminated' and forces the
+        worker down). Prefer cancel_optimization for a graceful stop.
+        """
+        return terminate_optimization_service(session_id)
+
+    @mcp.tool()
+    def purge_optimization_sessions(days_old: int = None) -> dict:
+        """
+        Permanently delete optimization sessions. If days_old is given, only delete
+        sessions older than that many days; otherwise delete all. Irreversible.
+        """
+        return purge_optimization_sessions_service(days_old)

--- a/jesse/mcp/tools/services/__init__.py
+++ b/jesse/mcp/tools/services/__init__.py
@@ -34,3 +34,16 @@ from .monte_carlo import (
     terminate_monte_carlo_service,
     purge_monte_carlo_sessions_service,
 )
+from .optimization import (
+    create_optimization_draft_service,
+    update_optimization_draft_service,
+    update_optimization_notes_service,
+    get_optimization_session_service,
+    get_optimization_sessions_service,
+    get_optimization_logs_service,
+    run_optimization_service,
+    rerun_optimization_service,
+    cancel_optimization_service,
+    terminate_optimization_service,
+    purge_optimization_sessions_service,
+)

--- a/jesse/mcp/tools/services/optimization.py
+++ b/jesse/mcp/tools/services/optimization.py
@@ -1,0 +1,756 @@
+"""
+Jesse Optimization Service Functions
+
+Mirrors the Monte Carlo service module so the MCP agent can stage and run
+hyperparameter optimizations with the same draft / run / poll workflow it
+already knows for backtests, RST, and Monte Carlo.
+
+Optimization differs from Monte Carlo in a few important ways:
+  - It uses a TRAIN/TEST split (four dates) instead of a single window, so the
+    optimizer tunes on the training window and reports out-of-sample metrics on
+    the testing window.
+  - objective_function, trials, and best_candidates_count are NOT top-level
+    request fields — the optimize mode's set_config() reads them off the `config`
+    dict, so they are folded into the config we send.
+  - The strategy MUST declare hyperparameters() (a non-empty list) or there is
+    nothing to optimize.
+  - `trials` is PER hyperparameter: total trials = n_hyperparameters * trials.
+  - Results are ranked best trials (params + train/test metrics), not an equity
+    distribution.
+
+Endpoints used (all under /optimization):
+    POST /update-state                 create or update a draft
+    POST /sessions/{id}                retrieve one session
+    POST /sessions                     list sessions
+    POST /sessions/{id}/notes          update notes / strategy code
+    POST /sessions/{id}/logs           log file content
+    POST /resume                       start an existing draft session
+    POST /rerun                        reset + restart a finished/stopped session
+    POST /cancel                       cooperative cancel
+    POST /terminate                    force-terminate
+    POST /purge-sessions               delete old sessions
+"""
+
+import json
+import os
+import uuid
+import requests
+from multiprocessing import cpu_count
+from typing import Optional
+
+import jesse.mcp.mcp_config as mcp_config
+from .auth import hash_password
+
+
+def _default_cpu_cores() -> int:
+    try:
+        return max(1, min(cpu_count() - 1, 4))
+    except Exception:
+        return 2
+
+
+def _default_optimize_config(
+    exchange_name: Optional[str],
+    objective_function: str = 'sharpe',
+    trials: int = 200,
+    best_candidates_count: int = 20,
+    warm_up_candles: int = 210,
+) -> dict:
+    """
+    Build the config payload the optimize runner expects.
+
+    The optimize mode's set_config() reads `objective_function`, `warm_up_candles`,
+    `trials`, and `best_candidates_count` off this dict (warm_up_candles and trials
+    are read unconditionally, so they must always be present). The Optimizer also
+    reads `config['exchange']['type'|'futures_leverage'|'futures_leverage_mode']`
+    unconditionally, so those exchange keys must always be present too (even for a
+    spot exchange) to avoid a KeyError inside the spawned worker.
+    """
+    name = (exchange_name or '').lower()
+    is_spot = 'spot' in name
+    exchange = {
+        'balance': 10_000,
+        'fee': 0.0006,
+        'type': 'spot' if is_spot else 'futures',
+        # Always present — Optimize.py indexes these regardless of exchange type.
+        'futures_leverage': 1,
+        'futures_leverage_mode': 'cross',
+    }
+    return {
+        'warm_up_candles': int(warm_up_candles),
+        'trials': int(trials),
+        'objective_function': objective_function or 'sharpe',
+        'best_candidates_count': int(best_candidates_count),
+        'exchange': exchange,
+    }
+
+
+def _build_default_title(routes_list: list) -> str:
+    if routes_list:
+        first = routes_list[0]
+        if isinstance(first, dict):
+            symbol = first.get('symbol') or 'Unknown Symbol'
+            timeframe = first.get('timeframe') or 'Unknown Timeframe'
+            strategy = first.get('strategy') or 'Unknown Strategy'
+            suffix = f" +{len(routes_list) - 1}" if len(routes_list) > 1 else ""
+            return f"MCP Optimization: {strategy} on {symbol} {timeframe}{suffix}"
+    return "MCP Optimization"
+
+
+def _normalize_title(title: str) -> str:
+    title = title.strip() if title else "MCP Optimization"
+    lowered = title.lower()
+    if "mcp" in lowered and "optim" in lowered:
+        return title
+    return f"MCP Optimization: {title}"
+
+
+def _build_default_description(
+    exchange: str,
+    routes_list: list,
+    training_start_date: str,
+    training_finish_date: str,
+    testing_start_date: str,
+    testing_finish_date: str,
+    objective_function: str,
+    trials: int,
+    strategy_summary: Optional[str],
+    hypothesis: Optional[str],
+    rationale: Optional[str],
+) -> str:
+    first = routes_list[0] if routes_list else {}
+    strategy_default = (
+        f"`{first.get('strategy', 'Unknown')}` on `{first.get('symbol', 'unknown')}` "
+        f"using the `{first.get('timeframe', 'unknown')}` timeframe."
+    )
+    summary_lines = [
+        f"- **Strategy:** {strategy_summary or strategy_default}",
+    ]
+    if hypothesis:
+        summary_lines.append(f"- **Hypothesis:** {hypothesis}")
+    if rationale:
+        summary_lines.append(f"- **Rationale:** {rationale}")
+    summary_lines.extend([
+        f"- **Training window:** `{training_start_date}` to `{training_finish_date}`",
+        f"- **Testing window:** `{testing_start_date}` to `{testing_finish_date}`",
+        f"- **Exchange:** `{exchange}`",
+        f"- **Objective:** `{objective_function}`",
+        f"- **Trials per hyperparameter:** {trials}",
+    ])
+    return (
+        "## MCP Optimization Notes\n\n"
+        "Generated by **Jesse MCP**.\n\n"
+        "### Summary\n\n"
+        + "\n".join(summary_lines)
+    )
+
+
+def _collect_strategy_codes(routes_list: list) -> dict:
+    strategy_codes = {}
+    for route in routes_list:
+        if not isinstance(route, dict):
+            continue
+        exchange = route.get('exchange')
+        symbol = route.get('symbol')
+        strategy = route.get('strategy')
+        if not exchange or not symbol or not strategy:
+            continue
+        key = f"{exchange}-{symbol}"
+        if key in strategy_codes:
+            continue
+        path = os.path.join('strategies', strategy, '__init__.py')
+        try:
+            if os.path.exists(path):
+                with open(path, 'r', encoding='utf-8') as f:
+                    strategy_codes[key] = f.read()
+        except Exception:
+            pass
+    return strategy_codes
+
+
+def _post_notes(api_url: str, auth: str, session_id: str, title: Optional[str],
+                description: Optional[str], strategy_codes: Optional[dict]) -> dict:
+    payload = {
+        'id': session_id,
+        'title': title,
+        'description': description,
+        'strategy_codes': strategy_codes,
+    }
+    response = requests.post(
+        f'{api_url}/optimization/sessions/{session_id}/notes',
+        json=payload,
+        headers={'Authorization': auth},
+        timeout=10,
+    )
+    if response.status_code == 200:
+        return {'status': 'success', 'message': 'Notes updated'}
+    if response.status_code == 401:
+        return {'status': 'error', 'message': 'Authentication failed'}
+    if response.status_code == 404:
+        return {'status': 'error', 'message': f'Session {session_id} not found'}
+    return {'status': 'error', 'message': f'Failed to update notes: {response.text}'}
+
+
+def create_optimization_draft_service(
+    exchange: str = "Binance Perpetual Futures",
+    routes: str = '[{"exchange": "Binance Perpetual Futures", "strategy": "ExampleStrategy", "symbol": "BTC-USDT", "timeframe": "4h"}]',
+    data_routes: str = '[]',
+    training_start_date: str = "2021-01-01",
+    training_finish_date: str = "2022-06-01",
+    testing_start_date: str = "2022-06-01",
+    testing_finish_date: str = "2023-01-01",
+    optimal_total: int = 50,
+    objective_function: str = "sharpe",
+    trials: int = 200,
+    best_candidates_count: int = 20,
+    warm_up_candles: int = 210,
+    fast_mode: bool = True,
+    cpu_cores: Optional[int] = None,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    strategy_summary: Optional[str] = None,
+    hypothesis: Optional[str] = None,
+    rationale: Optional[str] = None,
+) -> dict:
+    api_url = mcp_config.JESSE_API_URL
+    password = mcp_config.JESSE_PASSWORD
+
+    try:
+        auth = hash_password(password)
+        session_id = str(uuid.uuid4())
+
+        try:
+            routes_list = json.loads(routes)
+            data_routes_list = json.loads(data_routes)
+        except json.JSONDecodeError as e:
+            return {'status': 'error', 'message': 'Invalid JSON for routes/data_routes', 'details': str(e)}
+
+        if not isinstance(routes_list, list) or not isinstance(data_routes_list, list):
+            return {'status': 'error', 'message': 'routes and data_routes must be JSON arrays'}
+
+        if not routes_list:
+            return {'status': 'error', 'message': 'At least one trading route is required.'}
+
+        if objective_function and objective_function.lower() not in (
+            'sharpe', 'calmar', 'sortino', 'omega', 'serenity', 'smart sharpe', 'smart sortino'
+        ):
+            return {'status': 'error',
+                    'message': f'Unsupported objective_function "{objective_function}". '
+                               'Use one of: sharpe, calmar, sortino, omega, serenity, smart sharpe, smart sortino.'}
+
+        # The form stores both the run parameters and the optimization knobs
+        # (objective_function/trials/best_candidates_count/warm_up_candles) so the
+        # run step can rebuild the config dict without a separate config store.
+        form_data = {
+            'id': session_id,
+            'exchange': exchange,
+            'routes': routes_list,
+            'data_routes': data_routes_list,
+            'training_start_date': training_start_date,
+            'training_finish_date': training_finish_date,
+            'testing_start_date': testing_start_date,
+            'testing_finish_date': testing_finish_date,
+            'optimal_total': int(optimal_total),
+            'fast_mode': bool(fast_mode),
+            'cpu_cores': int(cpu_cores) if cpu_cores is not None else _default_cpu_cores(),
+            'objective_function': objective_function or 'sharpe',
+            'trials': int(trials),
+            'best_candidates_count': int(best_candidates_count),
+            'warm_up_candles': int(warm_up_candles),
+        }
+
+        state_dict = {
+            'form': form_data,
+            'results': {
+                'alert': {'message': '', 'type': ''},
+            },
+        }
+
+        response = requests.post(
+            f'{api_url}/optimization/update-state',
+            json={'id': session_id, 'state': state_dict},
+            headers={'Authorization': auth},
+            timeout=10,
+        )
+
+        if response.status_code == 401:
+            return {'status': 'error', 'message': 'Authentication failed'}
+        if response.status_code != 200:
+            return {'status': 'error', 'message': f'Failed to persist draft: {response.text}'}
+
+        note_title = _normalize_title(title or _build_default_title(routes_list))
+        note_description = description or _build_default_description(
+            exchange=exchange,
+            routes_list=routes_list,
+            training_start_date=training_start_date,
+            training_finish_date=training_finish_date,
+            testing_start_date=testing_start_date,
+            testing_finish_date=testing_finish_date,
+            objective_function=objective_function or 'sharpe',
+            trials=int(trials),
+            strategy_summary=strategy_summary,
+            hypothesis=hypothesis,
+            rationale=rationale,
+        )
+        strategy_codes = _collect_strategy_codes(routes_list)
+        notes_result = _post_notes(
+            api_url=api_url,
+            auth=auth,
+            session_id=session_id,
+            title=note_title,
+            description=note_description,
+            strategy_codes=strategy_codes or None,
+        )
+
+        result = {
+            'status': 'success',
+            'session_id': session_id,
+            'draft_state': state_dict,
+            'notes': {
+                'title': note_title,
+                'description': note_description,
+                'strategy_code_keys': list(strategy_codes.keys()),
+                'strategy_codes_captured': len(strategy_codes),
+            },
+            'dashboard_url': mcp_config.dashboard_url('optimization', session_id),
+            'message': f'Optimization draft created with ID: {session_id}',
+        }
+        if notes_result.get('status') != 'success':
+            result['warning'] = notes_result.get('message')
+        return result
+
+    except requests.exceptions.RequestException as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to connect to Jesse API'}
+    except Exception as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to create optimization draft'}
+
+
+def update_optimization_draft_service(session_id: str, state: str) -> dict:
+    api_url = mcp_config.JESSE_API_URL
+    password = mcp_config.JESSE_PASSWORD
+
+    try:
+        auth = hash_password(password)
+        state_dict = json.loads(state)
+
+        response = requests.post(
+            f'{api_url}/optimization/update-state',
+            json={'id': session_id, 'state': state_dict},
+            headers={'Authorization': auth},
+            timeout=10,
+        )
+
+        if response.status_code == 200:
+            return {
+                'status': 'success',
+                'session_id': session_id,
+                'draft_state': state_dict,
+                'message': 'Optimization draft updated successfully',
+            }
+        if response.status_code == 401:
+            return {'status': 'error', 'message': 'Authentication failed'}
+        return {'status': 'error', 'message': f'Failed to update draft: {response.text}'}
+
+    except json.JSONDecodeError as e:
+        return {'status': 'error', 'error': 'Invalid JSON format', 'details': str(e),
+                'message': 'Failed to parse state JSON'}
+    except requests.exceptions.RequestException as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to connect to Jesse API'}
+    except Exception as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to update optimization draft'}
+
+
+def update_optimization_notes_service(
+    session_id: str,
+    title: Optional[str] = None,
+    description: Optional[str] = None,
+    strategy_codes: Optional[str] = None,
+) -> dict:
+    api_url = mcp_config.JESSE_API_URL
+    password = mcp_config.JESSE_PASSWORD
+
+    try:
+        auth = hash_password(password)
+        parsed_codes = None
+        if strategy_codes is not None:
+            parsed_codes = json.loads(strategy_codes)
+            if not isinstance(parsed_codes, dict):
+                return {'status': 'error', 'message': 'strategy_codes must be a JSON object string'}
+
+        result = _post_notes(api_url, auth, session_id, title, description, parsed_codes)
+        if result.get('status') == 'success':
+            return {
+                'status': 'success',
+                'session_id': session_id,
+                'title': title,
+                'description': description,
+                'strategy_code_keys': list(parsed_codes.keys()) if parsed_codes else [],
+                'strategy_codes_captured': len(parsed_codes) if parsed_codes else 0,
+                'message': 'Optimization session notes updated successfully',
+            }
+        return result
+
+    except json.JSONDecodeError as e:
+        return {'status': 'error', 'error': 'Invalid JSON format', 'details': str(e),
+                'message': 'Failed to parse strategy_codes JSON'}
+    except requests.exceptions.RequestException as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to connect to Jesse API'}
+    except Exception as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to update optimization notes'}
+
+
+def get_optimization_session_service(session_id: str) -> dict:
+    api_url = mcp_config.JESSE_API_URL
+    password = mcp_config.JESSE_PASSWORD
+
+    try:
+        auth = hash_password(password)
+        response = requests.post(
+            f'{api_url}/optimization/sessions/{session_id}',
+            headers={'Authorization': auth},
+            timeout=10,
+        )
+        if response.status_code == 200:
+            data = response.json()
+            return {
+                'data': {'session': data.get('session', {})},
+                'dashboard_url': mcp_config.dashboard_url('optimization', session_id),
+                'error': None,
+                'message': 'Optimization session retrieved successfully',
+            }
+        if response.status_code == 404:
+            return {'data': None, 'error': f'Session {session_id} not found',
+                    'message': f'Session {session_id} not found'}
+        if response.status_code == 401:
+            return {'data': None, 'error': 'Authentication failed', 'message': 'Authentication failed'}
+        return {'data': None, 'error': f'Failed to retrieve session: {response.text}',
+                'message': f'Failed to retrieve session: {response.text}'}
+
+    except requests.exceptions.RequestException as e:
+        return {'data': None, 'error': f'Failed to connect to Jesse API: {str(e)}',
+                'message': f'Failed to connect to Jesse API: {str(e)}'}
+    except Exception as e:
+        return {'data': None, 'error': f'Failed to retrieve session: {str(e)}',
+                'message': f'Failed to retrieve session: {str(e)}'}
+
+
+def get_optimization_sessions_service(
+    limit: int = 50,
+    offset: int = 0,
+    title_search: Optional[str] = None,
+    status_filter: Optional[str] = None,
+    date_filter: Optional[str] = None,
+) -> dict:
+    api_url = mcp_config.JESSE_API_URL
+    password = mcp_config.JESSE_PASSWORD
+
+    try:
+        auth = hash_password(password)
+        payload = {
+            'limit': int(limit),
+            'offset': int(offset),
+            'title_search': title_search,
+            'status_filter': status_filter,
+            'date_filter': date_filter,
+        }
+        response = requests.post(
+            f'{api_url}/optimization/sessions',
+            json=payload,
+            headers={'Authorization': auth},
+            timeout=10,
+        )
+        if response.status_code == 200:
+            data = response.json()
+            return {
+                'status': 'success',
+                'sessions': data.get('sessions', []),
+                'count': data.get('count', 0),
+                'message': f'Retrieved {data.get("count", 0)} optimization session(s)',
+            }
+        if response.status_code == 401:
+            return {'status': 'error', 'message': 'Authentication failed'}
+        return {'status': 'error', 'message': f'Failed to retrieve sessions: {response.text}'}
+
+    except requests.exceptions.RequestException as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to connect to Jesse API'}
+    except Exception as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to retrieve optimization sessions'}
+
+
+def get_optimization_logs_service(session_id: str) -> dict:
+    api_url = mcp_config.JESSE_API_URL
+    password = mcp_config.JESSE_PASSWORD
+
+    try:
+        auth = hash_password(password)
+        response = requests.post(
+            f'{api_url}/optimization/sessions/{session_id}/logs',
+            headers={'Authorization': auth},
+            timeout=10,
+        )
+        if response.status_code == 200:
+            data = response.json()
+            return {
+                'status': 'success',
+                'session_id': session_id,
+                'logs': data.get('logs', ''),
+                'message': 'Logs retrieved successfully',
+            }
+        if response.status_code == 404:
+            return {'status': 'error', 'message': f'Log file for session {session_id} not found'}
+        if response.status_code == 401:
+            return {'status': 'error', 'message': 'Authentication failed'}
+        return {'status': 'error', 'message': f'Failed to retrieve logs: {response.text}'}
+
+    except requests.exceptions.RequestException as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to connect to Jesse API'}
+    except Exception as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to retrieve optimization logs'}
+
+
+def _build_run_payload(session_id: str, form: dict, state: dict) -> dict:
+    config = _default_optimize_config(
+        form.get('exchange'),
+        objective_function=form.get('objective_function', 'sharpe'),
+        trials=form.get('trials', 200),
+        best_candidates_count=form.get('best_candidates_count', 20),
+        warm_up_candles=form.get('warm_up_candles', 210),
+    )
+    return {
+        'id': session_id,
+        'exchange': form.get('exchange'),
+        'routes': form.get('routes', []),
+        'data_routes': form.get('data_routes', []),
+        'config': config,
+        'training_start_date': form.get('training_start_date'),
+        'training_finish_date': form.get('training_finish_date'),
+        'testing_start_date': form.get('testing_start_date'),
+        'testing_finish_date': form.get('testing_finish_date'),
+        'optimal_total': int(form.get('optimal_total', 50)),
+        'fast_mode': bool(form.get('fast_mode', True)),
+        'cpu_cores': int(form.get('cpu_cores', _default_cpu_cores())),
+        'state': state if isinstance(state, dict) else {},
+    }
+
+
+def _fetch_session(api_url: str, auth: str, session_id: str):
+    """Fetch an optimization session and return (form, state, status, err)."""
+    response = requests.post(
+        f'{api_url}/optimization/sessions/{session_id}',
+        headers={'Authorization': auth},
+        timeout=10,
+    )
+    if response.status_code == 404:
+        return None, None, None, {'status': 'error', 'message': f'Session {session_id} not found'}
+    if response.status_code == 401:
+        return None, None, None, {'status': 'error', 'message': 'Authentication failed'}
+    if response.status_code != 200:
+        return None, None, None, {'status': 'error', 'message': f'Failed to retrieve session: {response.text}'}
+
+    session_data = response.json().get('session', {})
+    session_status = session_data.get('status')
+    state = session_data.get('state')
+    if isinstance(state, str):
+        try:
+            state = json.loads(state)
+        except json.JSONDecodeError:
+            state = {}
+    form = state.get('form') if isinstance(state, dict) else None
+    if isinstance(form, str):
+        form = json.loads(form)
+    if not form:
+        return None, None, session_status, {
+            'status': 'error',
+            'message': 'No form found in session state. Create a draft first using create_optimization_draft.',
+        }
+    return form, state if isinstance(state, dict) else {}, session_status, None
+
+
+def _fire(api_url: str, auth: str, path: str, payload: dict) -> dict:
+    response = requests.post(
+        f'{api_url}{path}',
+        json=payload,
+        headers={'Authorization': auth},
+        timeout=10,
+    )
+    if response.status_code in (200, 202):
+        return {
+            'status': 'started',
+            'session_id': payload['id'],
+            'dashboard_url': mcp_config.dashboard_url('optimization', payload['id']),
+            'message': (
+                'Optimization started. Poll get_optimization_session(session_id) until status is '
+                '"finished" (or "stopped"/"terminated"). Optimization is long-running — poll less '
+                'frequently (e.g. every 20-30s) and watch completed_trials / total_trials.'
+            ),
+        }
+    if response.status_code == 401:
+        return {'status': 'error', 'message': 'Authentication failed'}
+    if response.status_code == 409:
+        return {'status': 'error', 'message': f'Session {payload["id"]} already exists / is running.'}
+    if response.status_code == 404:
+        return {'status': 'error', 'message': f'Session {payload["id"]} not found'}
+    return {'status': 'error', 'message': f'Failed to start optimization: {response.text}'}
+
+
+def run_optimization_service(session_id: str) -> dict:
+    """
+    Start a previously created optimization draft.
+
+    Goes to POST /optimization/resume (not POST /optimization): the draft row
+    already exists (create_optimization_draft persisted the form), and the main
+    endpoint 409s on a pre-existing row. /resume is the endpoint that requires an
+    existing row and launches the worker.
+    """
+    api_url = mcp_config.JESSE_API_URL
+    password = mcp_config.JESSE_PASSWORD
+
+    try:
+        auth = hash_password(password)
+        form, state, session_status, err = _fetch_session(api_url, auth, session_id)
+        if err:
+            return err
+
+        if session_status == 'running':
+            return {
+                'status': 'started',
+                'session_id': session_id,
+                'dashboard_url': mcp_config.dashboard_url('optimization', session_id),
+                'message': (
+                    f'Optimization session {session_id} is already running. '
+                    'Poll get_optimization_session(session_id) for progress.'
+                ),
+            }
+        if session_status == 'finished':
+            return {
+                'status': 'error',
+                'session_id': session_id,
+                'dashboard_url': mcp_config.dashboard_url('optimization', session_id),
+                'message': (
+                    f'Optimization session {session_id} has already finished. Read results via '
+                    'get_optimization_session(session_id), or use rerun_optimization(session_id) '
+                    'to run it again, or create a new draft.'
+                ),
+            }
+
+        payload = _build_run_payload(session_id, form, state)
+        return _fire(api_url, auth, '/optimization/resume', payload)
+
+    except requests.exceptions.RequestException as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to connect to Jesse API'}
+    except Exception as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to run optimization'}
+
+
+def rerun_optimization_service(session_id: str) -> dict:
+    """
+    Reset and restart an existing optimization session (clears prior trials/results).
+    Goes to POST /optimization/rerun. Use this to re-run a finished or stopped session.
+    """
+    api_url = mcp_config.JESSE_API_URL
+    password = mcp_config.JESSE_PASSWORD
+
+    try:
+        auth = hash_password(password)
+        form, state, session_status, err = _fetch_session(api_url, auth, session_id)
+        if err:
+            return err
+
+        if session_status == 'running':
+            return {
+                'status': 'error',
+                'session_id': session_id,
+                'message': (
+                    f'Optimization session {session_id} is currently running. Cancel it first '
+                    '(cancel_optimization) before rerunning.'
+                ),
+            }
+
+        payload = _build_run_payload(session_id, form, state)
+        return _fire(api_url, auth, '/optimization/rerun', payload)
+
+    except requests.exceptions.RequestException as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to connect to Jesse API'}
+    except Exception as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to rerun optimization'}
+
+
+def cancel_optimization_service(session_id: str) -> dict:
+    api_url = mcp_config.JESSE_API_URL
+    password = mcp_config.JESSE_PASSWORD
+
+    try:
+        auth = hash_password(password)
+        response = requests.post(
+            f'{api_url}/optimization/cancel',
+            json={'id': session_id},
+            headers={'Authorization': auth},
+            timeout=10,
+        )
+        if response.status_code == 202:
+            return {'status': 'success', 'session_id': session_id,
+                    'message': f'Optimization {session_id} cancellation requested'}
+        if response.status_code == 401:
+            return {'status': 'error', 'message': 'Authentication failed'}
+        return {'status': 'error', 'message': f'Failed to cancel: {response.text}'}
+
+    except requests.exceptions.RequestException as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to connect to Jesse API'}
+    except Exception as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to cancel optimization'}
+
+
+def terminate_optimization_service(session_id: str) -> dict:
+    api_url = mcp_config.JESSE_API_URL
+    password = mcp_config.JESSE_PASSWORD
+
+    try:
+        auth = hash_password(password)
+        response = requests.post(
+            f'{api_url}/optimization/terminate',
+            json={'id': session_id},
+            headers={'Authorization': auth},
+            timeout=10,
+        )
+        if response.status_code == 202:
+            return {'status': 'success', 'session_id': session_id,
+                    'message': f'Optimization {session_id} terminated'}
+        if response.status_code == 401:
+            return {'status': 'error', 'message': 'Authentication failed'}
+        return {'status': 'error', 'message': f'Failed to terminate: {response.text}'}
+
+    except requests.exceptions.RequestException as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to connect to Jesse API'}
+    except Exception as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to terminate optimization'}
+
+
+def purge_optimization_sessions_service(days_old: Optional[int] = None) -> dict:
+    api_url = mcp_config.JESSE_API_URL
+    password = mcp_config.JESSE_PASSWORD
+
+    try:
+        auth = hash_password(password)
+        payload = {'days_old': days_old}
+        response = requests.post(
+            f'{api_url}/optimization/purge-sessions',
+            json=payload,
+            headers={'Authorization': auth},
+            timeout=10,
+        )
+        if response.status_code == 200:
+            data = response.json()
+            deleted_count = data.get('deleted_count', 0)
+            return {
+                'status': 'success',
+                'deleted_count': deleted_count,
+                'message': f'Successfully purged {deleted_count} optimization session(s)',
+            }
+        if response.status_code == 401:
+            return {'status': 'error', 'message': 'Authentication failed'}
+        return {'status': 'error', 'message': f'Failed to purge sessions: {response.text}'}
+
+    except requests.exceptions.RequestException as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to connect to Jesse API'}
+    except Exception as e:
+        return {'status': 'error', 'error': str(e), 'message': 'Failed to purge optimization sessions'}

--- a/jesse/modes/optimize_mode/__init__.py
+++ b/jesse/modes/optimize_mode/__init__.py
@@ -37,79 +37,113 @@ def run(
     if cpu_cores > max_cpu_cores:
         raise ValueError(f'cpu_cores must be less than or equal to {max_cpu_cores} which is the number of cores on your machine.')
 
-    # inject config
-    set_config(user_config)
-    # add exchange to routes
-    for r in routes:
-        r['exchange'] = exchange
-    for r in data_routes:
-        r['exchange'] = exchange
-    # set routes
-    router.initiate(routes, data_routes)
-    store.app.set_session_id(session_id)
-    register_custom_exception_handler()
-    # validate routes
-    validate_routes(router)
+    # Persist a terminal error on any setup/run failure (most commonly insufficient
+    # candles for the training/testing windows, or a malformed config) so MCP/dashboard
+    # callers stop polling a session that would otherwise stay stuck. Without this, a
+    # candle shortage raised here surfaced to API clients as a silent hang.
+    try:
+        # inject config
+        set_config(user_config)
+        # add exchange to routes
+        for r in routes:
+            r['exchange'] = exchange
+        for r in data_routes:
+            r['exchange'] = exchange
+        # set routes
+        router.initiate(routes, data_routes)
+        store.app.set_session_id(session_id)
+        register_custom_exception_handler()
+        # validate routes
+        validate_routes(router)
 
-    # load historical candles
-    training_warmup_candles, training_candles, testing_warmup_candles, testing_candles = _get_training_and_testing_candles(
-        training_start_date,
-        training_finish_date,
-        testing_start_date,
-        testing_finish_date
-    )
-
-    # Capture strategy codes for each route
-    import os
-    strategy_codes = {}
-    for r in router.routes:
-        key = f"{r.exchange}-{r.symbol}"
-        if key not in strategy_codes:
-            try:
-                strategy_path = f'strategies/{r.strategy_name}/__init__.py'
-                
-                if os.path.exists(strategy_path):
-                    with open(strategy_path, 'r') as f:
-                        content = f.read()
-                    strategy_codes[key] = content
-            except Exception:
-                pass
-
-    # Check if we're resuming an existing session
-    existing_session = get_optimization_session_by_id(session_id)
-
-    if existing_session:
-        # Session exists, update it for resuming
-        update_optimization_session_status(session_id, 'running')
-        update_optimization_session_state(session_id, state, strategy_codes)
-
-        if jh.is_debugging():
-            jh.debug(f"Resuming existing optimization session with ID: {session_id}")
-    else:
-        # Session doesn't exist, create a new one
-        store_optimization_session(
-            id=session_id,
-            status='running',
-            strategy_codes=strategy_codes if strategy_codes else None
+        # load historical candles
+        training_warmup_candles, training_candles, testing_warmup_candles, testing_candles = _get_training_and_testing_candles(
+            training_start_date,
+            training_finish_date,
+            testing_start_date,
+            testing_finish_date
         )
-        update_optimization_session_state(session_id, state)
 
-        if jh.is_debugging():
-            jh.debug(f"Created new optimization session with ID: {session_id}")
+        # Capture strategy codes for each route
+        import os
+        strategy_codes = {}
+        for r in router.routes:
+            key = f"{r.exchange}-{r.symbol}"
+            if key not in strategy_codes:
+                try:
+                    strategy_path = f'strategies/{r.strategy_name}/__init__.py'
 
-    optimizer = Optimizer(
-        session_id,
-        user_config,
-        training_warmup_candles,
-        training_candles,
-        testing_warmup_candles,
-        testing_candles,
-        fast_mode,
-        optimal_total,
-        cpu_cores
-    )
+                    if os.path.exists(strategy_path):
+                        with open(strategy_path, 'r') as f:
+                            content = f.read()
+                        strategy_codes[key] = content
+                except Exception:
+                    pass
 
-    optimizer.run()
+        # Check if we're resuming an existing session
+        existing_session = get_optimization_session_by_id(session_id)
+
+        if existing_session:
+            # Session exists, update it for resuming
+            update_optimization_session_status(session_id, 'running')
+            update_optimization_session_state(session_id, state, strategy_codes)
+
+            if jh.is_debugging():
+                jh.debug(f"Resuming existing optimization session with ID: {session_id}")
+        else:
+            # Session doesn't exist, create a new one
+            store_optimization_session(
+                id=session_id,
+                status='running',
+                strategy_codes=strategy_codes if strategy_codes else None
+            )
+            update_optimization_session_state(session_id, state)
+
+            if jh.is_debugging():
+                jh.debug(f"Created new optimization session with ID: {session_id}")
+
+        optimizer = Optimizer(
+            session_id,
+            user_config,
+            training_warmup_candles,
+            training_candles,
+            testing_warmup_candles,
+            testing_candles,
+            fast_mode,
+            optimal_total,
+            cpu_cores
+        )
+
+        optimizer.run()
+    except Exception as e:
+        import traceback as _tb
+        from jesse.exceptions import CandlesNotFound, CandleNotFoundInDatabase
+        from jesse.models.OptimizationSession import (
+            get_optimization_session_by_id as _get_session,
+            store_optimization_session as _store_session,
+            update_optimization_session_status as _update_status,
+            add_session_exception as _add_exception,
+        )
+        if isinstance(e, (CandlesNotFound, CandleNotFoundInDatabase)):
+            payload = e.args[0] if getattr(e, 'args', None) else None
+            symbol = payload.get('symbol') if isinstance(payload, dict) else (routes[0].get('symbol') if routes else None)
+            warmup_num = jh.get_config('env.data.warmup_candles_num', 210)
+            message = (
+                f"Missing candles for {symbol} on {exchange}. Optimization needs candles for BOTH the "
+                f"training window ({training_start_date} to {training_finish_date}) and the testing window "
+                f"({testing_start_date} to {testing_finish_date}), plus ~{warmup_num} warm-up candles before "
+                f"each start. Import enough candles for {symbol} on {exchange} and re-run."
+            )
+        else:
+            message = str(e)
+        try:
+            if _get_session(session_id) is None:
+                _store_session(id=session_id, status='stopped')
+            _add_exception(session_id, message, _tb.format_exc())
+            _update_status(session_id, 'stopped')
+        except Exception:
+            pass
+        raise
 
 
 def _get_training_and_testing_candles(


### PR DESCRIPTION
## Summary
Adds MCP tool support for Jesse's hyperparameter **optimization** mode, mirroring the existing Monte Carlo MCP tools so an agent can stage, run, and poll optimizations with the same draft → run → poll workflow it already uses for backtests, RST, and Monte Carlo. Built on top of #580 (now merged).

## What's added
- **`jesse/mcp/tools/optimization.py`** — 11 `@mcp.tool` wrappers: `create_optimization_draft`, `update_optimization_draft`, `update_optimization_notes`, `get_optimization_session`, `get_optimization_sessions`, `get_optimization_logs`, `run_optimization`, `rerun_optimization`, `cancel_optimization`, `terminate_optimization`, `purge_optimization_sessions`.
- **`jesse/mcp/tools/services/optimization.py`** — service layer over the `/optimization` HTTP endpoints. Folds `objective_function` / `trials` / `best_candidates_count` / `warm_up_candles` + the singular `exchange` config into the `config` dict the optimize runner expects, builds the train/test run payload, and fires via `/optimization/resume` (the draft row already exists) / `/optimization/rerun`.
- Registered in `tools/__init__.py` and `services/__init__.py`.
- **`jesse/modes/optimize_mode/__init__.py`** — wrap `run()` so insufficient candles (or a config error) end the session `stopped` with a clear, actionable exception instead of hanging — the same robustness fix applied to backtest/RST in #580.

## Notes / behavior
- **Train/test split** (4 dates): tunes on the training window, reports out-of-sample metrics on the testing window so overfitting is visible per candidate.
- `objective_function` / `trials` / `best_candidates_count` ride **inside the `config` dict** (optimize mode's `set_config` reads them there), not as top-level request fields.
- `trials` is **per hyperparameter**: total trials = n_hyperparameters × trials.
- The strategy must declare a non-empty `hyperparameters()`.

## Testing (end-to-end via the MCP)
- A real optimization — EMA-crossover strategy with fast/slow period hyperparameters, BTC-USDT 4h, train 2023-01→2024-06 / test 2024-06→2024-12, 20 trials — **finished 20/20 with 10 ranked candidates**, each carrying training and testing metrics (winner fast=12/slow=35, train Sharpe 2.13 / test 1.72).
- A no-data symbol **stops in seconds** with a clear "import candles for both the training and testing windows" message (no silent hang).
- Monte Carlo (the template these tools mirror) verified working end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
