### PR TITLE
Fix fast/full simulator divergence on synthetic (Monte Carlo) candles

### DIFF
--- a/jesse/candle_pipelines/moving_block_bootstrap.py
+++ b/jesse/candle_pipelines/moving_block_bootstrap.py
@@ -3,7 +3,7 @@ from .base_candles import BaseCandlesPipeline
 
 
 class MovingBlockBootstrapCandlesPipeline(BaseCandlesPipeline):
-    def __init__(self, batch_size: int, **_ignored) -> None:
+    def __init__(self, batch_size: int, seed: int = None, **_ignored) -> None:
         """
         Generate synthetic candles by moving-block bootstrap on multivariate
         tuples of (delta_close, delta_high, delta_low).
@@ -14,6 +14,10 @@ class MovingBlockBootstrapCandlesPipeline(BaseCandlesPipeline):
             Size of the internal regeneration buffer in minutes. The pipeline
             derives a reasonable bootstrap block length from this, so there is
             no separate block-size argument.
+        seed : int, optional
+            Seed for the internal RNG. Leave None for independent random
+            scenarios (the normal case); pass an int for reproducible output
+            (used by tests asserting the fast and full simulators are identical).
         """
         super().__init__(batch_size)
 
@@ -25,7 +29,8 @@ class MovingBlockBootstrapCandlesPipeline(BaseCandlesPipeline):
         self._block_size = derived_block_size
 
         # Independent RNG per pipeline instance to avoid identical scenarios
-        self._rng = np.random.default_rng()
+        # (seedable for reproducible tests).
+        self._rng = np.random.default_rng(seed)
 
     def _bootstrap_blocks(self, arr: np.ndarray, n: int) -> np.ndarray:
         """

--- a/jesse/modes/backtest_mode.py
+++ b/jesse/modes/backtest_mode.py
@@ -583,6 +583,13 @@ def _step_simulator(
             if i != 0:
                 previous_short_candle = candles[j]['candles'][i - 1]
                 short_candle = _get_fixed_jumped_candle(previous_short_candle, short_candle)
+            # Persist the synthetic candle back into the array so the higher-timeframe
+            # generation below (and the next iteration's gap-fix reference) are built from the
+            # SYNTHETIC series — exactly as _skip_simulator does. Without this, larger-timeframe
+            # candles (and therefore the strategy's indicators) were generated from the ORIGINAL
+            # real candles while fills ran on the synthetic prices, so the full (step) simulator
+            # diverged from the fast (skip) simulator on bootstrapped candles — and could blow up.
+            candles[j]['candles'][i] = short_candle
             exchange = candles[j]['exchange']
             symbol = candles[j]['symbol']
 

--- a/tests/test_simulator_parity.py
+++ b/tests/test_simulator_parity.py
@@ -1,0 +1,79 @@
+import numpy as np
+
+import jesse.helpers as jh
+from jesse import research
+from jesse.config import reset_config
+from jesse.factories import candles_from_close_prices
+from jesse.strategies import Strategy
+from jesse.candle_pipelines.moving_block_bootstrap import MovingBlockBootstrapCandlesPipeline
+
+# the trading-timeframe candles the strategy actually sees, captured per run
+_RECORDED = []
+
+
+class _CandleRecorderStrategy(Strategy):
+    """Records every trading-timeframe candle it is shown. The values come from the candles the
+    simulator feeds the strategy — exactly the quantity the fast/full parity bug corrupted."""
+
+    def before(self) -> None:
+        _RECORDED.append((
+            round(float(self.open), 6), round(float(self.close), 6),
+            round(float(self.high), 6), round(float(self.low), 6),
+        ))
+
+    def should_long(self) -> bool:
+        return False
+
+    def should_short(self) -> bool:
+        return False
+
+    def should_cancel_entry(self) -> bool:
+        return True
+
+    def go_long(self) -> None:
+        pass
+
+    def go_short(self) -> None:
+        pass
+
+
+def _candles_seen(fast_mode: bool) -> list:
+    # isolate from whatever ran before in the suite: reset config + clear lru_cached mode helpers
+    reset_config()
+    for fn in (jh.app_mode, jh.is_live, jh.is_livetrading, jh.is_optimizing, jh.is_paper_trading):
+        fn.cache_clear()
+
+    # ~3000 1m candles on a 5m timeframe => the simulator must build 5m candles from the
+    # (synthetic) 1m series. A seeded pipeline makes both runs see identical synthetic candles.
+    closes = (100 + np.cumsum(np.random.RandomState(0).normal(0, 0.6, 3000))).tolist()
+    fake = candles_from_close_prices(closes)
+    exchange, symbol, timeframe = 'Fake Exchange', 'FAKE-USDT', '5m'
+    config = {
+        'starting_balance': 10_000, 'fee': 0.0, 'type': 'futures',
+        'futures_leverage': 2, 'futures_leverage_mode': 'cross',
+        'exchange': exchange, 'warm_up_candles': 0,
+    }
+    routes = [{'exchange': exchange, 'strategy': _CandleRecorderStrategy, 'symbol': symbol, 'timeframe': timeframe}]
+    candles = {jh.key(exchange, symbol): {'exchange': exchange, 'symbol': symbol, 'candles': fake}}
+
+    _RECORDED.clear()
+    research.backtest(
+        config, routes, [], candles, fast_mode=fast_mode,
+        candles_pipeline_class=MovingBlockBootstrapCandlesPipeline,
+        candles_pipeline_kwargs={'batch_size': 500, 'seed': 7},
+    )
+    return list(_RECORDED)
+
+
+def test_fast_and_full_simulators_feed_identical_candles_with_pipeline():
+    """
+    The fast (skip) and full (step) simulators must show the strategy IDENTICAL candles, even
+    when a candle pipeline injects synthetic candles. Regression for a bug where the step
+    simulator generated higher-timeframe candles from the ORIGINAL candles instead of the
+    synthetic ones, so the strategy's view (and indicators) diverged from the fills.
+    """
+    fast = _candles_seen(True)
+    full = _candles_seen(False)
+
+    assert len(fast) > 100  # the strategy actually saw candles (guard against a vacuous pass)
+    assert fast == full


### PR DESCRIPTION
## The bug
Fast Mode is meant to be a speed-only toggle, but `fast_mode` ON vs OFF produced **different** results for Monte Carlo (candle-bootstrap) runs — and the full/step path would blow up (balance overflowing into `InsufficientMargin` / `Infinity`, which also broke the session API's JSON → "Internal Server Error"). On **real** candles the two modes already agreed; they only diverged on the **synthetic** bootstrapped candles.

## Root cause
In `_step_simulator` (full mode), the pipeline's synthetic candle was used for fills but **never written back** into `candles[...]`. So:
- higher-timeframe candle generation (`candles[j]['candles'][i-(count-1):i+1]`), and
- the gap-fix reference (`candles[j]['candles'][i-1]`)

were taken from the **original real** candles, while fills ran on the **synthetic** prices. The strategy's indicators (sma/ema/atr) therefore came from real data while it traded on synthetic data — divergence, and for risk-sized strategies, runaway compounding. `_skip_simulator` (fast mode) already writes the synthetic candles back (`candles[j]['candles'][i:i+candles_step] = short_candles`), which is why it was correct.

## Fix
One line in `_step_simulator`: persist the synthetic candle back into the array, exactly like `_skip_simulator`. It's a **no-op for normal (pipeline-less) backtests** (writes the candle back to itself).

## Verification
- Deterministic comparison (seeded pipeline → identical synthetic candles): fast vs full now produce **byte-identical trades**, including the full BTC-USDT 4h / 2-year case that previously exploded (58 == 58 trades). Before the fix the first trade already diverged (entry 47570 vs 45173, atr $1195 vs $3339).
- Real-candle regression: fast == full across several strategies/timeframes, results unchanged.
- Full test suite: **478 passed** (added `tests/test_simulator_parity.py`, which fails before this fix).

Also adds a seedable RNG to `MovingBlockBootstrapCandlesPipeline` (used by the regression test; normal runs stay random).

## Context
Stacked on the earlier change that defaulted MCP/dashboard Monte Carlo to Fast Mode (the robust path) so MC worked again immediately. This PR makes Fast Mode ON/OFF truly identical, so that default is no longer load-bearing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)