### PR TITLE
MCP usage limits: guests need an account (0 runs by default)

### DIFF
--- a/jesse/mcp/USAGE_LIMITS.md
+++ b/jesse/mcp/USAGE_LIMITS.md
@@ -18,7 +18,7 @@ Everything else (config/candle/strategy/indicator reads, *draft*
 creation/updates, status polls, `get_*_session`, logs, cancel/terminate,
 purge, …) is FREE and unmetered.
 
-Daily budgets (UTC day): **guests = 0** (no research runs at all — they must sign up),
+Daily budgets (UTC day): **guests = 0** (no research runs without an account),
 **free (logged-in) = 100**; any paid plan is **unlimited**.
 
 All of the above are config constants in `jesse/mcp/usage_limits.py` and are
@@ -26,7 +26,7 @@ overridable via environment variables:
 
 | Env var                              | Default | Meaning                          |
 |--------------------------------------|---------|----------------------------------|
-| `MCP_GUEST_DAILY_CREDITS`            | 0       | Daily budget for guests (no token); 0 = must sign up|
+| `MCP_GUEST_DAILY_CREDITS`            | 0       | Daily budget for guests (no token); 0 = needs an account|
 | `MCP_FREE_DAILY_CREDITS`             | 100     | Daily budget for free (logged-in)|
 | `MCP_CREDIT_WEIGHT_BACKTEST`         | 1       | Credit cost of `run_backtest`    |
 | `MCP_CREDIT_WEIGHT_SIGNIFICANCE_TEST`| 1       | Credit cost of `run_significance_test`|
@@ -45,26 +45,25 @@ reads the `plan` field (`free` / `guest` / `basic` / `pro` / `enterprise` /
 
 - Any PAID plan (anything that isn't `free`/`guest`) → always allowed (unlimited).
 - **`free`** (logged in, not paid) → metered at the free budget (100/day); the
-  over-limit nudge is "upgrade to premium".
+  over-limit message notes that premium has no daily limit.
 - **`guest`** — i.e. NO license token at all → guest budget is **0** by default, so
-  guests get **no research runs** and are nudged to **sign up** for a free account.
+  guests get **no research runs**; the message states that a free account is required.
   A missing token means *guest*, NOT *error*, so this is deliberately not fail-open.
 - **Plan undetermined** — a real backend error (token present but `/v2/user-info`
   is unreachable / non-200 / malformed) → **FAIL OPEN** (allow the run, log a
   warning). We never block a legit user because our own metering plumbing is down —
-  a soft nudge, not a hard wall.
+  a soft limit, not a hard wall.
 
 > The whole feature is **client-side**: the counter lives in the user's own Redis
 > (see below) and the plan comes from the existing license read above. No new
 > backend endpoint is required. A determined user can bypass a client-side limit;
-> that's an accepted trade-off for a nudge.
+> that's an accepted trade-off for a lenient, client-side limit.
 
 ## Limit-reached response
 
 When a user is over budget, the gated tool returns this structured dict (it does
 NOT raise — that would break the MCP client). The `message` and `is_guest` differ
-for guests (nudged to **sign up** for a free account) vs free users (nudged to
-**upgrade** to premium):
+for guests (a free account is required) vs free users (premium has no daily limit):
 
 ```json
 {

--- a/jesse/mcp/USAGE_LIMITS.md
+++ b/jesse/mcp/USAGE_LIMITS.md
@@ -18,15 +18,15 @@ Everything else (config/candle/strategy/indicator reads, *draft*
 creation/updates, status polls, `get_*_session`, logs, cancel/terminate,
 purge, …) is FREE and unmetered.
 
-Daily budgets (UTC day): **guests = 50**, **free (logged-in) = 100**; any paid plan
-is **unlimited**.
+Daily budgets (UTC day): **guests = 0** (no research runs at all — they must sign up),
+**free (logged-in) = 100**; any paid plan is **unlimited**.
 
 All of the above are config constants in `jesse/mcp/usage_limits.py` and are
 overridable via environment variables:
 
 | Env var                              | Default | Meaning                          |
 |--------------------------------------|---------|----------------------------------|
-| `MCP_GUEST_DAILY_CREDITS`            | 50      | Daily budget for guests (no token)|
+| `MCP_GUEST_DAILY_CREDITS`            | 0       | Daily budget for guests (no token); 0 = must sign up|
 | `MCP_FREE_DAILY_CREDITS`             | 100     | Daily budget for free (logged-in)|
 | `MCP_CREDIT_WEIGHT_BACKTEST`         | 1       | Credit cost of `run_backtest`    |
 | `MCP_CREDIT_WEIGHT_SIGNIFICANCE_TEST`| 1       | Credit cost of `run_significance_test`|
@@ -46,9 +46,9 @@ reads the `plan` field (`free` / `guest` / `basic` / `pro` / `enterprise` /
 - Any PAID plan (anything that isn't `free`/`guest`) → always allowed (unlimited).
 - **`free`** (logged in, not paid) → metered at the free budget (100/day); the
   over-limit nudge is "upgrade to premium".
-- **`guest`** — i.e. NO license token at all → metered at the smaller guest budget
-  (50/day); the over-limit nudge is "log in for a higher limit". A missing token
-  means *guest*, NOT *error*, so this is deliberately not fail-open.
+- **`guest`** — i.e. NO license token at all → guest budget is **0** by default, so
+  guests get **no research runs** and are nudged to **sign up** for a free account.
+  A missing token means *guest*, NOT *error*, so this is deliberately not fail-open.
 - **Plan undetermined** — a real backend error (token present but `/v2/user-info`
   is unreachable / non-200 / malformed) → **FAIL OPEN** (allow the run, log a
   warning). We never block a legit user because our own metering plumbing is down —
@@ -63,7 +63,8 @@ reads the `plan` field (`free` / `guest` / `basic` / `pro` / `enterprise` /
 
 When a user is over budget, the gated tool returns this structured dict (it does
 NOT raise — that would break the MCP client). The `message` and `is_guest` differ
-for guests (nudged to log in) vs free users (nudged to upgrade):
+for guests (nudged to **sign up** for a free account) vs free users (nudged to
+**upgrade** to premium):
 
 ```json
 {

--- a/jesse/mcp/usage_limits.py
+++ b/jesse/mcp/usage_limits.py
@@ -70,9 +70,9 @@ def _env_int(name: str, default: int) -> int:
 # unlimited. Override with MCP_FREE_DAILY_CREDITS (e.g. export MCP_FREE_DAILY_CREDITS=200).
 FREE_DAILY_CREDITS = _env_int("MCP_FREE_DAILY_CREDITS", 100)
 
-# Daily budget for GUEST users (no license token at all). Default 0 — guests can't run
-# the research tools at all; they're nudged to sign up for a (free) account. Override
-# with MCP_GUEST_DAILY_CREDITS if you ever want to grant guests a small daily allowance.
+# Daily budget for GUEST users (no license token at all). Default 0 — without an
+# account, guests can't run the research tools at all. Override with
+# MCP_GUEST_DAILY_CREDITS if you ever want to grant guests a small daily allowance.
 GUEST_DAILY_CREDITS = _env_int("MCP_GUEST_DAILY_CREDITS", 0)
 
 # Per-tool credit cost. Every expensive run — backtest, significance test, Monte Carlo,
@@ -199,7 +199,7 @@ def _plan_is_premium(plan: str) -> bool:
     The license backend's free tier reports 'free' (and signed-out/guest reports
     'guest'); every paid plan (basic / pro / enterprise / lifetime / premium / …)
     is treated as unlimited. Anything we don't recognize as free is treated as
-    paid — failing toward NOT blocking, since this is a soft nudge, not a wall.
+    paid — failing toward NOT blocking; the limit is meant to be lenient, not strict.
     """
     if not plan:
         return False
@@ -375,9 +375,9 @@ def _limit_reached_response(result: ConsumeResult, is_guest: bool = False) -> di
     """
     Build the friendly, structured 'limit_reached' dict returned to the client.
 
-    A guest (no license token) is nudged to SIGN UP for a free account — by default
-    guests can't run the research tools at all. A free user is nudged to UPGRADE to
-    premium (unlimited).
+    A guest (no license token) is told a free account is required — by default guests
+    can't run the research tools at all. A free user is shown that premium has no
+    daily limit.
     """
     default_limit = GUEST_DAILY_CREDITS if is_guest else FREE_DAILY_CREDITS
     limit = result.limit if result.limit is not None else default_limit
@@ -387,8 +387,7 @@ def _limit_reached_response(result: ConsumeResult, is_guest: bool = False) -> di
         message = (
             "Running research through the AI assistant — backtests, Monte Carlo, "
             "optimizations, and significance tests — requires a Jesse account. "
-            "Sign up for free at jesse.trade to get started; premium gives you "
-            "unlimited runs."
+            "Sign up for free at jesse.trade to get started."
         )
     else:
         message = (
@@ -440,9 +439,9 @@ def gated(weight: int, meter_factory=get_usage_meter, plan_getter=get_user_plan)
             if plan is None:
                 return func(*args, **kwargs)
 
-            # 4) Guest (no license token) or free → meter it. Guests get the smaller
-            #    daily allowance + a "log in for more" nudge; free users get the full
-            #    allowance + an "upgrade to premium" nudge.
+            # 4) Guest (no license token) or free → meter it. Guests get the guest
+            #    allowance (0 by default → a free account is required); free users get
+            #    the free allowance, with premium noted as having no daily limit.
             is_guest = str(plan).strip().lower() == 'guest'
             limit = GUEST_DAILY_CREDITS if is_guest else FREE_DAILY_CREDITS
             try:

--- a/jesse/mcp/usage_limits.py
+++ b/jesse/mcp/usage_limits.py
@@ -70,9 +70,10 @@ def _env_int(name: str, default: int) -> int:
 # unlimited. Override with MCP_FREE_DAILY_CREDITS (e.g. export MCP_FREE_DAILY_CREDITS=200).
 FREE_DAILY_CREDITS = _env_int("MCP_FREE_DAILY_CREDITS", 100)
 
-# Daily budget for GUEST users (no license token at all) — smaller than the free tier,
-# to nudge them to log in. Override with MCP_GUEST_DAILY_CREDITS.
-GUEST_DAILY_CREDITS = _env_int("MCP_GUEST_DAILY_CREDITS", 50)
+# Daily budget for GUEST users (no license token at all). Default 0 — guests can't run
+# the research tools at all; they're nudged to sign up for a (free) account. Override
+# with MCP_GUEST_DAILY_CREDITS if you ever want to grant guests a small daily allowance.
+GUEST_DAILY_CREDITS = _env_int("MCP_GUEST_DAILY_CREDITS", 0)
 
 # Per-tool credit cost. Every expensive run — backtest, significance test, Monte Carlo,
 # optimization — costs exactly 1 credit; there is no weighting. (Kept per-tool and
@@ -374,8 +375,9 @@ def _limit_reached_response(result: ConsumeResult, is_guest: bool = False) -> di
     """
     Build the friendly, structured 'limit_reached' dict returned to the client.
 
-    A guest (no license token) is nudged to LOG IN — even a free account gets a
-    higher daily limit. A free user is nudged to UPGRADE to premium (unlimited).
+    A guest (no license token) is nudged to SIGN UP for a free account — by default
+    guests can't run the research tools at all. A free user is nudged to UPGRADE to
+    premium (unlimited).
     """
     default_limit = GUEST_DAILY_CREDITS if is_guest else FREE_DAILY_CREDITS
     limit = result.limit if result.limit is not None else default_limit
@@ -383,9 +385,10 @@ def _limit_reached_response(result: ConsumeResult, is_guest: bool = False) -> di
     reset_at = result.reset_at or _reset_at_iso()
     if is_guest:
         message = (
-            f"Daily guest limit reached ({used} of {limit} research runs used today). "
-            f"Log in to get a higher daily limit, or go premium for unlimited runs. "
-            f"Resets at 00:00 UTC."
+            "Running research through the AI assistant — backtests, Monte Carlo, "
+            "optimizations, and significance tests — requires a Jesse account. "
+            "Sign up for free at jesse.trade to get started; premium gives you "
+            "unlimited runs."
         )
     else:
         message = (

--- a/tests/test_mcp_usage_limits.py
+++ b/tests/test_mcp_usage_limits.py
@@ -88,7 +88,7 @@ def test_default_weights_and_limit():
     assert ul.CREDIT_WEIGHTS["run_monte_carlo"] == 1
     assert ul.CREDIT_WEIGHTS["run_optimization"] == 1
     assert ul.FREE_DAILY_CREDITS == 100
-    assert ul.GUEST_DAILY_CREDITS == 50
+    assert ul.GUEST_DAILY_CREDITS == 0      # guests can't run research tools at all
 
 
 def test_weights_overridable_via_env(monkeypatch):
@@ -252,14 +252,15 @@ def test_free_over_limit_returns_structured_response_without_running():
     assert blocked["reset_at"]                   # ISO timestamp present
 
 
-def test_guest_over_limit_nudges_to_log_in():
+def test_guest_is_blocked_and_nudged_to_sign_up():
+    # Guests get 0 — the very first run is blocked, with a sign-up nudge (no daily reset).
     redis = FakeRedis()
-    tool, calls = _make_gated(50, "guest", redis, limit=50)
-    assert tool()["status"] == "started"            # 50/50 ok
-    blocked = tool()                                 # over
+    tool, calls = _make_gated(1, "guest", redis, limit=0)
+    blocked = tool()
+    assert calls["n"] == 0                            # tool body never ran
     assert blocked["status"] == "limit_reached"
     assert blocked["is_guest"] is True
-    assert "Log in" in blocked["message"]            # guests get the log-in nudge
+    assert "Sign up" in blocked["message"]           # nudge to create a (free) account
     assert "Upgrade to premium" not in blocked["message"]
 
 

--- a/tests/test_mcp_usage_limits.py
+++ b/tests/test_mcp_usage_limits.py
@@ -247,20 +247,20 @@ def test_free_over_limit_returns_structured_response_without_running():
     assert blocked["limit"] == 50
     assert blocked["is_guest"] is False
     assert "Upgrade to premium" in blocked["message"]
-    assert "Log in" not in blocked["message"]    # free users get the upgrade nudge, not log-in
+    assert "Sign up" not in blocked["message"]   # free users get the premium message, not the account one
     assert "00:00 UTC" in blocked["message"]
     assert blocked["reset_at"]                   # ISO timestamp present
 
 
-def test_guest_is_blocked_and_nudged_to_sign_up():
-    # Guests get 0 — the very first run is blocked, with a sign-up nudge (no daily reset).
+def test_guest_is_blocked_and_told_an_account_is_required():
+    # Guests get 0 — the very first run is blocked, with an account-required message (no reset).
     redis = FakeRedis()
     tool, calls = _make_gated(1, "guest", redis, limit=0)
     blocked = tool()
     assert calls["n"] == 0                            # tool body never ran
     assert blocked["status"] == "limit_reached"
     assert blocked["is_guest"] is True
-    assert "Sign up" in blocked["message"]           # nudge to create a (free) account
+    assert "account" in blocked["message"].lower()   # message states a free account is required
     assert "Upgrade to premium" not in blocked["message"]
 
 


### PR DESCRIPTION
Follow-up to #583. Guests (no license token) get **0** research runs by default, so the MCP research tools require an account.

- `GUEST_DAILY_CREDITS` default **50 → 0**: a guest is blocked on the very first run.
- The guest message states that a free account is required (and where to create one); it does **not** mention premium.
- Free (100/day) and paid (unlimited) are unchanged.
- Still fully client-side; only a real backend error fails open.
- Tests + doc updated.