### PR TITLE
Fix circular-import crash when a project .env is missing

### DIFF
--- a/jesse/services/env.py
+++ b/jesse/services/env.py
@@ -32,17 +32,21 @@ if jh.is_jesse_project():
 
     # validation for existence of .env file
     if len(list(ENV_VALUES.keys())) == 0:
-        jh.error(
+        # NOTE: print directly here instead of jh.error(). This code runs at import time,
+        # before the rest of Jesse is initialized, and env.py is imported by
+        # jesse.services.redis. jh.error() calls is_live() -> jesse.config ->
+        # jesse.modes.utils -> jesse.services.logger -> jesse.services.redis, which is
+        # still mid-import — so jh.error() here triggers a circular ImportError that hides
+        # this very message. A plain stderr print + os._exit keeps the message visible.
+        print(
             '.env file is missing from within your local project. '
             'This usually happens when you\'re in the wrong directory. '
             '\n\nIf you haven\'t created a Jesse project yet, do that by running: \n'
             'jesse make-project {name}\n'
             'And then go into that project, and run the same command.',
-            force_print=True
+            file=sys.stderr,
         )
         os._exit(1)
-        jh.terminate_app()
-        # raise FileNotFoundError('.env file is missing from within your local project. This usually happens when you\'re in the wrong directory. You can create one by running "cp .env.example .env"')
 
     if not jh.is_unit_testing() and ENV_VALUES['PASSWORD'] == '':
         raise EnvironmentError('You forgot to set the PASSWORD in your .env file')


### PR DESCRIPTION
`jesse/services/env.py` validates that a project `.env` exists at import time. When it's missing it called `jh.error(...)` — but `jh.error()` → `is_live()` → `jesse.config` → `jesse.modes.utils` → `jesse.services.logger` → `jesse.services.redis`, and `services.redis` is exactly what imports `env.py`, so it's still mid-import. The result is a cryptic `cannot import name 'sync_publish' from partially initialized module 'jesse.services.redis'` ImportError that completely hides the intended ".env is missing" message.

(Surfaced while setting up the strategy-executor — Jesse running from a dir without a `.env`.)

**Fix:** print the message directly to stderr (no heavy import chain) + `os._exit(1)`. The clear guidance now shows and the process exits cleanly.

- Behaviour with a valid `.env` is unchanged.
- Verified: from a no-`.env` dir it now prints the clear message + exits 1 (was: circular ImportError).
- Full suite green (498 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)