### PR TITLE
Fix MCP optimization sessions failing to load in the dashboard

### DIFF
--- a/jesse/mcp/tools/services/optimization.py
+++ b/jesse/mcp/tools/services/optimization.py
@@ -259,9 +259,27 @@ def create_optimization_draft_service(
             'warm_up_candles': int(warm_up_candles),
         }
 
+        # Persist the FULL results shape the dashboard's optimization store expects (see
+        # dashboard-v1 stores/optimizationStore.ts state()). The frontend's loadSession patches
+        # this state in and then reads nested objects directly (results.progressbar.current,
+        # results.exception.error); a partial shape here left those undefined and crashed
+        # "Failed to load session". Keep this in sync with the store's default results.
         state_dict = {
             'form': form_data,
             'results': {
+                'showResults': False,
+                'executing': False,
+                'logsModal': False,
+                'status': '',
+                'progressbar': {'current': 0, 'estimated_remaining_seconds': 0},
+                'routes_info': [],
+                'best_candidates': [],
+                'metrics': [],
+                'generalInfo': [],
+                'selectedObjectiveMetric': '',
+                'infoLogs': '',
+                'info': [],
+                'exception': {'error': '', 'traceback': ''},
                 'alert': {'message': '', 'type': ''},
             },
         }


### PR DESCRIPTION
The MCP optimization draft persisted an incomplete `results` state (`{alert}` only). The dashboard's `loadSession` $patches that state and then reads `results.progressbar.current` / `results.exception.error` directly → MCP-created sessions crashed with **Failed to load session** (dashboard-run ones work because the store is pre-filled). This persists the **complete** results shape (matching dashboard-v1 `optimizationStore.ts` state()).

Pairs with dashboard-v1 PR (the `_ensureResultsShape` guard, which also recovers already-saved broken sessions). The dashboard must be rebuilt into `jesse/static` at release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)