### PR TITLE
MCP usage limits: default the meter to remote

### DIFF
--- a/jesse/mcp/usage_limits.py
+++ b/jesse/mcp/usage_limits.py
@@ -85,14 +85,14 @@ CREDIT_WEIGHTS = {
     "run_optimization": _env_int("MCP_CREDIT_WEIGHT_OPTIMIZATION", 1),
 }
 
-# Which meter backend to use:
-#   "local"  — Redis daily counter on this machine + plan read from api1 (the default for now;
-#              soft, trivially bypassable since the user controls their own Redis).
+# Which meter backend to use (default "remote"):
 #   "remote" — the licensing backend owns the daily limit: it resolves the plan from the license
 #              token, holds the counter, and returns the remaining allowance. Authoritative (so the
 #              limit can't be bypassed by editing the local counter). Fails open if the backend is
-#              unreachable. Activate in production with MCP_USAGE_METER=remote.
-USAGE_METER_BACKEND = os.environ.get("MCP_USAGE_METER", "local").strip().lower()
+#              unreachable, so it never disrupts usage. This is the default; no env var needed.
+#   "local"  — opt-out fallback: a Redis daily counter on this machine + plan read from api1
+#              (soft, trivially bypassable since the user controls their own Redis).
+USAGE_METER_BACKEND = os.environ.get("MCP_USAGE_METER", "remote").strip().lower()
 
 # Redis key prefix for the local meter's daily counters.
 _REDIS_KEY_PREFIX = "jesse:mcp:usage"

--- a/tests/test_mcp_usage_limits.py
+++ b/tests/test_mcp_usage_limits.py
@@ -15,7 +15,16 @@ or license backend is needed, and they're deterministic + isolated.
 
 import importlib
 
+import pytest
+
 import jesse.mcp.usage_limits as ul
+
+
+@pytest.fixture(autouse=True)
+def _force_local_backend(monkeypatch):
+    """The module default is now "remote"; most tests below exercise the LOCAL flow, so force it.
+    The remote-path tests opt back in by setting ul.USAGE_METER_BACKEND = "remote" themselves."""
+    monkeypatch.setattr(ul, "USAGE_METER_BACKEND", "local")
 
 
 # ---------------------------------------------------------------------------
@@ -321,8 +330,11 @@ def test_fail_open_when_meter_raises():
     assert calls["n"] == 1
 
 
-def test_meter_selection_default_is_local():
-    assert isinstance(ul.get_usage_meter(), ul.LocalUsageMeter)
+def test_meter_default_is_remote(monkeypatch):
+    # With no env override, the module defaults to the remote (server-authoritative) backend.
+    monkeypatch.delenv("MCP_USAGE_METER", raising=False)
+    importlib.reload(ul)
+    assert ul.USAGE_METER_BACKEND == "remote"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Makes the server-authoritative meter the default (was `local`) so the daily limit is enforced by the backend with no env var — no client needs to add a setting. `MCP_USAGE_METER=local` remains as an opt-out. Fails open, so a backend outage never disrupts usage.

Tests: an autouse fixture forces local mode for the existing local-flow tests; added a default-is-remote check. All 26 pass (`pytest tests/test_mcp_usage_limits.py -p no:anyio`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)