### PR TITLE
Fix TypeError in get_order_by_id when client_id is an int

### DIFF
--- a/jesse/store/state_orders.py
+++ b/jesse/store/state_orders.py
@@ -102,7 +102,10 @@ class OrdersState:
         if use_exchange_id:
             return fnc.find(lambda o: o.exchange_id == id, self.storage[key])
 
-        # make sure id (client_id) is not and empty string
+        # a client_id may arrive as an int (e.g. Binance algo ids); coerce before matching
+        id = str(id) if id is not None else ''
+
+        # make sure id (client_id) is not an empty string
         if id == '':
             return None
 

--- a/tests/test_state_orders.py
+++ b/tests/test_state_orders.py
@@ -62,6 +62,24 @@ def test_state_order_get_order_by_id():
     assert store.orders.get_order_by_id(exchanges.SANDBOX, 'BTC-USD', o2.id) == o2
 
 
+def test_state_order_get_order_by_id_with_int_id():
+    # regression #820: get_order_by_id must not crash when the client_id is an int
+    set_up()
+
+    o1 = fake_order({'exchange': exchanges.SANDBOX, 'symbol': 'BTC-USD'})
+    o1.id = 'algo-987654-xyz'  # controlled id with a numeric run to match against
+    store.orders.add_order(o1)
+
+    # an int id that isn't present must return None (not raise)
+    assert store.orders.get_order_by_id(exchanges.SANDBOX, 'BTC-USD', 123456789) is None
+
+    # an int id whose string form is a substring of an existing order's id still matches
+    assert store.orders.get_order_by_id(exchanges.SANDBOX, 'BTC-USD', 987654) == o1
+
+    # None is treated like an empty id -> None, not a crash
+    assert store.orders.get_order_by_id(exchanges.SANDBOX, 'BTC-USD', None) is None
+
+
 def test_state_order_get_orders():
     set_up()
 


### PR DESCRIPTION
## Problem
`OrdersState.get_order_by_id` matches a client_id with `id in str(o.id)`. When `id` arrives as an **int** rather than a str, that raises:
```
TypeError: 'in <string>' requires string as left operand, not int
```
Some exchange order-stream payloads carry numeric ids (e.g. Binance algo/strategy order ids), so this crashed the live order-status polling thread (`_check_orders_status` → `handle_order_stream` → `get_order_by_id`).

## Fix
Coerce `id` to `str` (and treat `None` like an empty id → return `None`) before the substring match. Behavior is unchanged for the normal string-id callers; it just no longer raises on an int.

Adds a regression test in `tests/test_state_orders.py` covering an int id (present and absent) and `None`.