### PR TITLE
Fetch the Jesse Live plugin (download + releases-info) from api2

### DIFF
--- a/jesse/services/general_info.py
+++ b/jesse/services/general_info.py
@@ -1,7 +1,7 @@
 import os
 import requests
 import jesse.helpers as jh
-from jesse.info import exchange_info, jesse_supported_timeframes, JESSE_API_URL
+from jesse.info import exchange_info, jesse_supported_timeframes, JESSE_API_URL, JESSE_API2_URL
 from jesse.services.env import is_dev_env
 
 
@@ -94,7 +94,7 @@ def get_general_info(has_live=False) -> dict:
             raise ValueError("Invalid response from PyPI")
             
         response = requests.get(
-            JESSE_API_URL + '/plugins/live/releases/info',
+            JESSE_API2_URL + '/plugins/live/releases/info',
             timeout=10
         )
         if response.status_code == 200 and 'application/json' in response.headers.get('Content-Type', ''):

--- a/jesse/services/installer.py
+++ b/jesse/services/installer.py
@@ -6,7 +6,7 @@ import subprocess
 import sys
 import click
 import os
-from jesse.info import JESSE_API_URL
+from jesse.info import JESSE_API_URL, JESSE_API2_URL
 
 def _pip_install(package):
     subprocess.check_call([sys.executable, "-m", "pip", "install", package])
@@ -70,7 +70,7 @@ def install(is_live_plugin_already_installed: bool, strict: bool):
     print('Downloading the latest version of the live-trade plugin...')
     try:
         response = requests.post(
-            JESSE_API_URL + '/download-release',
+            JESSE_API2_URL + '/download-release',
             headers={'Authorization': 'Bearer ' + access_token},
             params={
                 'os': formatted_os_name,
@@ -81,7 +81,7 @@ def install(is_live_plugin_already_installed: bool, strict: bool):
         )
     except requests.exceptions.RequestException:
         response = requests.post(
-            'https://api1.jesse.trade/api/download-release',
+            JESSE_API2_URL + '/download-release',
             headers={'Authorization': 'Bearer ' + access_token},
             params={
                 'os': formatted_os_name,


### PR DESCRIPTION
The Jesse Live plugin releases endpoints are moving to the api2 backend. This points the live-plugin **installer's download** (`jesse/services/installer.py`) and the **releases-info lookup** (`general_info.py`) at `JESSE_API2_URL` instead of api1.

- `installer.py`: both the primary and fallback download URLs → `JESSE_API2_URL + '/download-release'`.
- `general_info.py`: `/plugins/live/releases/info` → `JESSE_API2_URL`.
- The license check (`/v2/user-info`) is **unchanged** (stays on api1).

Ships with the next core release. Old clients keep downloading from api1 (which stays up), so nothing breaks for existing installs.