### PR TITLE
Fix Bitfinex import retry crashing on jh.random_uniform

### DIFF
--- a/jesse/modes/import_candles_mode/drivers/Bitfinex/BitfinexSpot.py
+++ b/jesse/modes/import_candles_mode/drivers/Bitfinex/BitfinexSpot.py
@@ -1,5 +1,6 @@
 import requests
 import time
+import random
 from requests.exceptions import ConnectionError, RequestException
 
 import jesse.helpers as jh
@@ -33,7 +34,7 @@ class BitfinexSpot(CandleExchange):
                     raise e
                 
                 # Exponential backoff with jitter
-                delay = (self.base_delay * 2 ** attempt) + (jh.random_uniform(0, 1))
+                delay = (self.base_delay * 2 ** attempt) + random.uniform(0, 1)
                 time.sleep(delay)
 
     def get_starting_time(self, symbol: str) -> int:


### PR DESCRIPTION
Fixes #601.

`_make_request` in the Bitfinex Spot import driver called `jh.random_uniform(0, 1)` for its backoff
jitter. That function does not exist, so every transient `ConnectionError` raised `AttributeError`
**from inside the exception handler** — the retry never happened and the import worker died.

This is the first of the two options offered in the issue: use the stdlib directly. `random` was not
yet imported in this module.

```diff
 import requests
 import time
+import random
 from requests.exceptions import ConnectionError, RequestException
```
```diff
-                delay = (self.base_delay * 2 ** attempt) + (jh.random_uniform(0, 1))
+                delay = (self.base_delay * 2 ** attempt) + random.uniform(0, 1)
```

**Why the stdlib rather than adding `random_uniform` to `jesse.helpers`** (the alternative in the
issue): there is only this one call site, so a new public helper would add API surface for nothing,
and direct `import random` already has precedent in the codebase — `jesse/services/color.py` and
`jesse/research/monte_carlo/monte_carlo_trades.py` both do it. Happy to switch to the helper
approach if you prefer it.

Note that `jh.random` does resolve today, but only because `jesse/helpers.py` imports the stdlib
`random` module at line 8 — it is a namespace leak, not part of the helpers API, so
`jh.random.uniform(...)` would depend on another module's imports.

Restored behaviour: with `max_retries = 5` and `base_delay = 3`, delays are ~3/6/12/24s plus 0–1s
jitter, then the last attempt re-raises — bounded at 5 requests and ~49s. Steady-state import rate
is unchanged (`rate_limit_per_second = 1`).

`jh` is still used elsewhere in the file, so its import stays.

**Scope:** deliberately limited to the reported bug. While looking at this I noticed
`requests.get` in `_make_request` has no `timeout`, while several sibling drivers (Binance, Bybit,
Kraken, Gate USDT) pass one — which means a stalled connection can now hang the retry loop rather
than fail fast. I left it out to keep this PR to the issue, but I'm glad to send it separately, or
fold it in here if you'd rather have both at once.

**Testing:** verified `jh.random_uniform` is the only occurrence in the codebase, that the module
parses and imports cleanly, and that the Gate driver's backoff (which has no jitter) is unaffected.
No test added — there is currently no coverage for the import drivers, as they are network-dependent.
