### PR TITLE
Fix timeframe docstring listing lowercase 1d/3d/1w

### DIFF
--- a/jesse/utils.py
+++ b/jesse/utils.py
@@ -331,7 +331,7 @@ def timeframe_to_one_minutes(timeframe: str) -> int:
 
     :param timeframe: str - The timeframe to convert. Supported timeframes include:
         - '1m', '3m', '5m', '15m', '30m', '45m', '1h', '2h', '3h', '4h', '6h', '8h', '12h', 
-          '1d', '3d', '1w', '1M'.
+          '1D', '3D', '1W', '1M'.
     :return: int - The equivalent number of minutes for the given timeframe.
 
     :raises InvalidTimeframe: If the provided timeframe is not supported.


### PR DESCRIPTION
Refs #603 (the documentation half of it).

`timeframe_to_one_minutes` documents `'1d'`, `'3d'`, `'1w'` as supported, but
`TIMEFRAME_TO_ONE_MINUTES` is keyed off `enums.timeframes`, which only defines the uppercase forms:

```python
>>> from jesse.utils import TIMEFRAME_TO_ONE_MINUTES as T
>>> '1d' in T, '1D' in T
(False, True)
```

So following the function's own docstring raises `InvalidTimeframe`. `'1M'` was already correct,
which is what makes the lowercase entries read as intentional rather than a typo.

Uppercase is clearly the canonical form elsewhere in the repo — `jesse/mcp/resources/candle.md`
documents the same list uppercase, and `tests/test_utils.py` already asserts
`timeframe_to_one_minutes("1D") == 60 * 24`.

Docstring only, no behaviour change.

**Scope:** this does not address the other half of #603 (an invalid timeframe is not validated
before the backtest process is spawned, so the API answers `202` and the session silently stays in
`draft`). That fix has design choices I'd rather not make unilaterally — happy to send it once you
say where the validation belongs.

Note the lowercase `'1d'`/`'1w'` strings in the exchange driver utils are deliberately untouched:
those map Jesse's `'1D'` to each exchange's own API interval string.
