### PR TITLE
Add request timeout to Bitfinex candle import

### DIFF
--- a/jesse/modes/import_candles_mode/drivers/Bitfinex/BitfinexSpot.py
+++ b/jesse/modes/import_candles_mode/drivers/Bitfinex/BitfinexSpot.py
@@ -26,7 +26,7 @@ class BitfinexSpot(CandleExchange):
     def _make_request(self, url: str, params: dict = None) -> requests.Response:
         for attempt in range(self.max_retries):
             try:
-                response = requests.get(url, params=params)
+                response = requests.get(url, params=params, timeout=30)
                 return response
             except (ConnectionError, RequestException) as e:
                 if attempt == self.max_retries - 1:  # Last attempt


### PR DESCRIPTION
Follow-up offered in #602. Refs #601.

`requests.get` in `_make_request` had no `timeout`, so a stalled connection could block the import
indefinitely. `timeout=30` matches the two closest analogues — `BinanceMain.py` (whose
`_make_request` is structurally identical, retry loop included) and `GateUSDTMain.py`. Bybit and
Kraken use 10–15s on comparable endpoints.

**Why this matters beyond "it eventually gives up":** on `master` a stalled socket means the worker
process never dies, so `_cleanup_finished_workers` never sees `is_alive() == False`, the
`active_workers` Redis entry is never removed, and the import keeps reporting `running` forever
while leaking a process and a Postgres connection. A timeout is what lets that path terminate at all.

Partial imports are safe to interrupt: `store_candles_list` is a single
`insert_many(...).on_conflict_ignore()` with no surrounding transaction, and `Candle` has a unique
index on `(exchange, symbol, timeframe, timestamp)`, so re-running skips already-stored ranges.

**Merge-order note:** `requests.exceptions.Timeout` subclasses `RequestException`, so the existing
`except` clause has the right shape — but the handler body currently calls the non-existent
`jh.random_uniform` (#601 / #602). Until that lands, a stall surfaces as an `AttributeError` chained
from the `Timeout` rather than a clean retry. Still strictly better than hanging forever, but
#602 first gives the better result. The two are textually independent; I verified they merge with
no conflicts in either order.

**Scope:** limited to this driver, matching the shape of c80693b9 ("Prevent notifier loop thread
from dying on transient network errors"). Several other `requests` call sites in the codebase also
lack timeouts — glad to send those separately if you'd like them.

No test added: there is no Bitfinex coverage in `tests/test_import_candles.py`, and a meaningful
timeout assertion would require mocking the socket layer.
