### PR TITLE
Reorder trade returns instead of absolute PnLs in trades Monte Carlo

### DIFF
--- a/jesse/research/monte_carlo/monte_carlo_trades.py
+++ b/jesse/research/monte_carlo/monte_carlo_trades.py
@@ -96,6 +96,7 @@ class MonteCarloTradesReturn(TypedDict):
 @ray.remote
 def _ray_run_scenario_monte_carlo(
     original_trades: list,
+    original_returns: List[float],
     original_equity_curve: list,
     starting_balance: float,
     scenario_index: int,
@@ -106,10 +107,11 @@ def _ray_run_scenario_monte_carlo(
             scenario_seed = seed + scenario_index
             random.seed(scenario_seed)
             np.random.seed(scenario_seed)
-        shuffled_trades = original_trades.copy()
-        random.shuffle(shuffled_trades)
-        equity_curve = _reconstruct_equity_curve_from_trades(
-            shuffled_trades, original_equity_curve, starting_balance
+        order = list(range(len(original_trades)))
+        random.shuffle(order)
+        shuffled_trades = [original_trades[i] for i in order]
+        equity_curve = _reconstruct_equity_curve_from_returns(
+            [original_returns[i] for i in order], original_equity_curve, starting_balance
         )
         result = _calculate_metrics_from_equity_curve(equity_curve, starting_balance)
         result['trades'] = shuffled_trades
@@ -186,10 +188,13 @@ def _run_monte_carlo_simulation(
             original_result, config
         )
         pbar = _setup_progress_bar(progress_bar, num_scenarios, "Monte Carlo Scenarios")
+        # validate and convert once here: raised inside a Ray worker this would be swallowed by the
+        # per-scenario except clause and the session would finish green with no data
+        returns_ref = ray.put(_fractional_returns(original_trades, starting_balance))
         trades_ref = ray.put(original_trades)
         equity_curve_ref = ray.put(original_equity_curve)
         scenario_refs = _launch_monte_carlo_scenarios(
-            num_scenarios, trades_ref, equity_curve_ref, starting_balance
+            num_scenarios, trades_ref, returns_ref, equity_curve_ref, starting_balance
         )
         results = _process_scenario_results(scenario_refs, pbar, progress_callback, result_callback)
         if pbar:
@@ -258,6 +263,7 @@ def _diagnose_empty_trades(original_result: dict) -> None:
 def _launch_monte_carlo_scenarios(
     num_scenarios: int,
     trades_ref: Any,
+    returns_ref: Any,
     equity_curve_ref: Any,
     starting_balance: float
 ) -> List[Any]:
@@ -265,6 +271,7 @@ def _launch_monte_carlo_scenarios(
     for i in range(num_scenarios):
         ref = _ray_run_scenario_monte_carlo.remote(
             original_trades=trades_ref,
+            original_returns=returns_ref,
             original_equity_curve=equity_curve_ref,
             starting_balance=starting_balance,
             scenario_index=i,
@@ -274,7 +281,45 @@ def _launch_monte_carlo_scenarios(
     return scenario_refs
 
 
-def _reconstruct_equity_curve_from_trades(shuffled_trades: list, original_equity_curve: list, starting_balance: float) -> list:
+def _fractional_returns(trades: list, starting_balance: float) -> List[float]:
+    """
+    Express each trade's PnL as a fraction of the balance it was sized against.
+
+    Position size is normally derived from available capital, so a trade's absolute PnL only means
+    something next to the balance at the time the trade was taken. Reordering requires quantities
+    that are comparable across the equity curve, which the fractions are and the raw PnLs are not.
+
+    The balance is taken as `starting_balance + cumsum(PNL)`, which is exact for a single route
+    holding one position at a time. With several routes a trade is opened while other positions
+    still tie up capital, so the denominator is an approximation there.
+
+    Raises:
+        ValueError: if any trade lost at least the balance backing it. Its fraction is then <= -100%,
+            which no ordering can absorb, and every later fraction is measured against a balance that
+            no longer exists.
+    """
+    balance = starting_balance
+    returns: List[float] = []
+    for trade in trades:
+        if balance <= 0 or trade['PNL'] <= -balance:
+            raise ValueError(
+                'A trade lost at least the balance backing it, so trade-order Monte Carlo is undefined'
+            )
+        returns.append(trade['PNL'] / balance)
+        balance += trade['PNL']
+    return returns
+
+
+def _reconstruct_equity_curve_from_returns(shuffled_returns: List[float], original_equity_curve: list, starting_balance: float) -> list:
+    """
+    Rebuild an equity curve by applying the reordered trade returns to the starting balance.
+
+    Takes fractional returns rather than absolute PnLs so that a trade taken late in a grown
+    account is not replayed at its original dollar size against a much smaller early balance.
+
+    Every fraction is greater than -100% by construction, so the balance stays positive whatever the
+    ordering and the drawdown can no longer read as deeper than a total loss.
+    """
     if not original_equity_curve or not original_equity_curve[0].get('data'):
         raise ValueError("Invalid original equity curve format")
     original_data = original_equity_curve[0]['data']
@@ -285,15 +330,19 @@ def _reconstruct_equity_curve_from_trades(shuffled_trades: list, original_equity
     }]
     current_balance = starting_balance
     trade_index = 0
-    total_trades = len(shuffled_trades)
+    total_trades = len(shuffled_returns)
     total_time_points = len(time_points)
     trades_per_point = total_trades / total_time_points if total_time_points > 0 else 1
     for i, timestamp in enumerate(time_points):
-        target_trades_completed = int((i + 1) * trades_per_point)
+        # the last point takes whatever int() truncation left behind, so every trade is applied and
+        # the final value stays invariant to ordering
+        target_trades_completed = (
+            total_trades if i == total_time_points - 1 else int((i + 1) * trades_per_point)
+        )
         trades_to_add = target_trades_completed - trade_index
         for _ in range(trades_to_add):
             if trade_index < total_trades:
-                current_balance += shuffled_trades[trade_index]['PNL']
+                current_balance *= 1 + shuffled_returns[trade_index]
                 trade_index += 1
         new_equity_curve[0]['data'].append({
             'time': timestamp,

--- a/tests/test_monte_carlo_trades.py
+++ b/tests/test_monte_carlo_trades.py
@@ -1,0 +1,77 @@
+import random
+
+import pytest
+
+from jesse.research.monte_carlo.monte_carlo_trades import (
+    _calculate_metrics_from_equity_curve,
+    _fractional_returns,
+    _reconstruct_equity_curve_from_returns,
+)
+
+STARTING_BALANCE = 10_000.0
+# a compounding run: the later trades move far more money than the early balance ever held
+PNLS = [500, -300, 2000, -1500, 40000, -25000]
+# a daily curve carries far more points than trades, which is where the scheduling loop does work
+SHAPES = [len(PNLS), 365, 3287]
+
+
+def _curve(returns: list, points: int) -> list:
+    shell = [{'name': 'Portfolio', 'data': [{'time': i, 'value': 0} for i in range(points)]}]
+    return _reconstruct_equity_curve_from_returns(returns, shell, STARTING_BALANCE)
+
+
+def _values(returns: list, points: int) -> list:
+    return [point['value'] for point in _curve(returns, points)[0]['data']]
+
+
+@pytest.mark.parametrize('points', SHAPES)
+def test_original_order_reproduces_the_realised_balance(points):
+    returns = _fractional_returns([{'PNL': pnl} for pnl in PNLS], STARTING_BALANCE)
+    assert _values(returns, points)[-1] == pytest.approx(STARTING_BALANCE + sum(PNLS))
+
+
+@pytest.mark.parametrize('points', SHAPES)
+def test_reordering_keeps_the_final_value_and_never_goes_negative(points):
+    returns = _fractional_returns([{'PNL': pnl} for pnl in PNLS], STARTING_BALANCE)
+    random.seed(0)
+    for _ in range(50):
+        shuffled = returns[:]
+        random.shuffle(shuffled)
+        values = _values(shuffled, points)
+        assert values[-1] == pytest.approx(STARTING_BALANCE + sum(PNLS))
+        assert min(values) > 0
+
+
+@pytest.mark.parametrize('points', SHAPES)
+def test_no_ordering_reports_a_drawdown_deeper_than_a_total_loss(points):
+    # the regression this guards: replaying absolute PnLs put the balance below zero, and a 9-year
+    # run reported a 5th-percentile drawdown of -2204%
+    returns = _fractional_returns([{'PNL': pnl} for pnl in PNLS], STARTING_BALANCE)
+    random.seed(0)
+    for _ in range(50):
+        shuffled = returns[:]
+        random.shuffle(shuffled)
+        metrics = _calculate_metrics_from_equity_curve(_curve(shuffled, points), STARTING_BALANCE)
+        assert metrics['max_drawdown'] >= -100
+
+
+def test_reordering_still_moves_the_drawdown():
+    returns = _fractional_returns([{'PNL': pnl} for pnl in PNLS], STARTING_BALANCE)
+    random.seed(0)
+    seen = set()
+    for _ in range(50):
+        shuffled = returns[:]
+        random.shuffle(shuffled)
+        metrics = _calculate_metrics_from_equity_curve(_curve(shuffled, 365), STARTING_BALANCE)
+        seen.add(round(metrics['max_drawdown'], 6))
+    assert len(seen) > 1
+
+
+@pytest.mark.parametrize('pnls', [
+    (5000, -20000, 3000, 4000),   # wiped out mid-run
+    (9000, 3000, 4000, -30000),   # wiped out on the final trade
+    (-10000, 5000),               # lost exactly the starting balance
+])
+def test_a_run_that_lost_the_balance_backing_a_trade_is_rejected(pnls):
+    with pytest.raises(ValueError):
+        _fractional_returns([{'PNL': pnl} for pnl in pnls], STARTING_BALANCE)


### PR DESCRIPTION
Fixes #607.

## The problem

The trades mode shuffles a backtest's closed trades and replays their absolute `PNL` against a running balance. Position size is normally derived from available capital, so a trade's absolute PnL only means something next to the balance it was sized against. Once the account has grown, a late trade carries a dollar amount the early balance could never have produced, and replaying it first takes the balance below zero — which `_calculate_max_drawdown` reports faithfully as a drawdown past -100%.

The same strategy and settings, over two windows:

| window | final balance | worst_5 `max_drawdown` |
|---|---|---|
| Binance Perp BTC-USDT, 2020-06 → 2026-07 | 10,000 → 139,080 | -271% |
| Bitfinex Spot BTC-USD, 2017-08 → 2026-07 | 10,000 → 614,384 | -2204% |

The figure tracks how long the account had to compound, not the risk being taken.

## The change

Express each trade as a fraction of the balance it was sized against, in the original order, and compound the reordered fractions. The final value stays invariant to ordering, as before; the path, and therefore the drawdown, still depends on it, which is what the simulation measures. Every fraction is greater than -100% by construction, so the balance stays positive whatever the ordering.

Three things follow from that:

**A run where some trade lost the balance backing it is rejected** with `ValueError`. Such a trade has no fraction any ordering could absorb, and every later fraction would be measured against a balance that no longer exists.

**The conversion runs once before the scenarios are launched**, not inside each Ray worker. A raise inside the task would be caught by the per-scenario `except Exception`, and the caller would return an empty result set without propagating — the session ends up marked `finished`, with no data and one traceback per scenario in the log. It also removes a redundant O(n) recomputation per worker.

**The remainder is drained at the final time point.** `int((i + 1) * trades_per_point)` truncates, so for shapes like 27 trades over 3287 daily points the last trade was never applied. Because it was the last of the *shuffled* order, the dropped value varied per scenario: 27 distinct final values across 300 reorderings of one backtest, none matching the realised final. This is pre-existing and affects the old path equally, but the invariant above depends on it, so I fixed it here rather than claim something the code does not do. Happy to split it out if you would rather review it separately.

`result['trades']` is unchanged: shuffling an index list keeps trades and returns paired, and because `random.shuffle` never inspects the elements it moves, the permutation is identical to the previous one for any given seed.

## Two things worth flagging

**`sharpe_ratio` becomes order-invariant in this mode.** Under multiplicative compounding with at most one trade per equity-curve point — the usual case, since the curve is daily — the per-point returns are a permutation of the same multiset, so mean and standard deviation no longer vary across scenarios. I believe that is the mathematically correct outcome, since reordering should move the path and not the return distribution, but it is visible in two places: `print_monte_carlo_trades_summary` drops metrics whose std falls below `1e-12`, so the Sharpe row disappears there, while `MonteCarloRunner._extract_trades_summary_metrics` has no such filter and will render a row whose worst/median/best are identical, with a p-value degenerated to 0.0 or 1.0 feeding `significant_metrics_5pct`. Containing it at the source — skipping degenerate metrics in `_calculate_confidence_intervals` — would fix both consumers, but it changes behaviour beyond this bug so I left it out. Tell me which you would prefer and I will follow up. `calmar_ratio` still varies through the drawdown.

**This changes the model for fixed-size strategies.** For a strategy trading a constant position size, absolute PnL *is* the right quantity to reorder and the previous behaviour was correct. Fractions are the safer default because sizing from available capital is what the framework's own guidance recommends (`AGENTS.md`: *"Never use fixed quantities — use available sizing utilities"*), but it is a modelling choice and I wanted to be explicit rather than present it as a pure bug fix.

## Tests

`tests/test_monte_carlo_trades.py`. The regression guard is that no ordering reports a drawdown deeper than a total loss; alongside it, the original ordering reproduces the balance the backtest finished on, any reordering keeps that final value and stays positive, reordering still moves the drawdown, and a run with a balance-losing trade is rejected — mid-run, on the final trade, and at exactly the starting balance.

Each is parametrised over three curve shapes including 3287 points against 6 trades, because a daily curve carries far more points than trades and that is where the scheduling loop does its work. Both helpers are pure, so no ray, database or candles are needed.

```
$ python -m pytest tests/test_monte_carlo_trades.py -q
.............                                                            [100%]
13 passed in 6.47s
```
