### PR TITLE
feat: deflated Sharpe ratio for optimization trials

### DIFF
--- a/jesse/modes/optimize_mode/Optimize.py
+++ b/jesse/modes/optimize_mode/Optimize.py
@@ -330,12 +330,15 @@ class Optimizer:
             return
         skew = metrics_dict.get('returns_skewness')
         kurt = metrics_dict.get('returns_kurtosis')
+        # The moments are missing exactly when the return series had no dispersion, and
+        # deflated_sharpe_ratio returns nan for that. Substituting normal moments here
+        # would instead hand it a Sharpe of ~1e16 to deflate, which answers 1.0.
         metrics_dict['deflated_sharpe_ratio'] = deflated_sharpe_ratio(
             sharpe,
             observations,
             self.n_trials,
-            skew=skew if skew is not None and np.isfinite(skew) else 0.0,
-            kurt=kurt if kurt is not None and np.isfinite(kurt) else 3.0,
+            skew=skew if skew is not None else np.nan,
+            kurt=kurt if kurt is not None else np.nan,
         )
 
     def _process_trial_result(self, result):

--- a/jesse/modes/optimize_mode/Optimize.py
+++ b/jesse/modes/optimize_mode/Optimize.py
@@ -11,6 +11,7 @@ import jesse.services.logger as logger
 from jesse import exceptions
 from jesse.services.redis import sync_publish
 from jesse.modes.optimize_mode.fitness import get_fitness
+from jesse.services.metrics import deflated_sharpe_ratio
 from jesse.routes import router
 from jesse.services.progressbar import Progressbar
 from jesse.services.redis import is_process_active
@@ -317,6 +318,26 @@ class Optimizer:
             logger.log_optimize_mode(f"Error creating Optuna trial: {e}", self.session_id )
             return False
 
+    def _attach_deflated_sharpe(self, metrics_dict) -> None:
+        """Adds 'deflated_sharpe_ratio' to a metrics dict, keyed to this
+        study's total trial count. No-op when the inputs are missing (e.g.
+        trials with too few trades)."""
+        if not metrics_dict:
+            return
+        sharpe = metrics_dict.get('sharpe_ratio')
+        observations = metrics_dict.get('sharpe_observations')
+        if sharpe is None or not observations:
+            return
+        skew = metrics_dict.get('returns_skewness')
+        kurt = metrics_dict.get('returns_kurtosis')
+        metrics_dict['deflated_sharpe_ratio'] = deflated_sharpe_ratio(
+            sharpe,
+            observations,
+            self.n_trials,
+            skew=skew if skew is not None and np.isfinite(skew) else 0.0,
+            kurt=kurt if kurt is not None and np.isfinite(kurt) else 3.0,
+        )
+
     def _process_trial_result(self, result):
         """Process the result of a completed trial"""
         trial_number = result['trial_number']
@@ -328,6 +349,13 @@ class Optimizer:
         # Update progress
         self.completed_trials += 1
         self.progressbar.update()
+
+        # A study of n_trials attempts selects its best trial, so each trial's
+        # Sharpe is restated as P(true SR > expected max of n_trials zero-skill
+        # trials) — without this, a large enough study promotes the luckiest
+        # trial rather than the best strategy.
+        self._attach_deflated_sharpe(training_metrics)
+        self._attach_deflated_sharpe(testing_metrics)
 
         # Store trial in Optuna for persistence
         self._create_optuna_trial(trial_number, params, score, training_metrics, testing_metrics)

--- a/jesse/services/metrics.py
+++ b/jesse/services/metrics.py
@@ -83,6 +83,52 @@ def sharpe_ratio(returns, rf=0.0, periods=365, annualize=True, smart=False):
     return pd.Series([res])
 
 
+def expected_max_sharpe(n_trials: int, sr_std: float) -> float:
+    """
+    Expected per-period Sharpe of the best of `n_trials` zero-skill strategies
+    whose Sharpe estimates have standard deviation `sr_std`
+    (Bailey & Lopez de Prado, 2014).
+    """
+    from scipy import stats as scipy_stats
+
+    if n_trials < 1:
+        raise ValueError('n_trials must be >= 1')
+    if n_trials == 1:
+        return 0.0
+    euler = 0.5772156649015329
+    z1 = scipy_stats.norm.ppf(1 - 1 / n_trials)
+    z2 = scipy_stats.norm.ppf(1 - 1 / (n_trials * np.e))
+    return float(sr_std * ((1 - euler) * z1 + euler * z2))
+
+
+def deflated_sharpe_ratio(
+        sharpe: float, n_observations: int, n_trials: int,
+        skew: float = 0.0, kurt: float = 3.0, periods=365
+) -> float:
+    """
+    P(true Sharpe > expected max Sharpe of `n_trials` zero-skill trials):
+    the probability that a result selected as the best of `n_trials` attempts
+    reflects skill rather than selection (Bailey & Lopez de Prado, 2014).
+
+    `sharpe` is the ANNUALIZED value as reported by sharpe_ratio() and is
+    de-annualized internally: the formula operates on per-period Sharpe, and
+    feeding it an annualized value inflates the statistic by ~sqrt(periods).
+    `kurt` is non-excess kurtosis (normal = 3).
+    """
+    from scipy import stats as scipy_stats
+
+    if n_observations < 3 or not np.isfinite(sharpe):
+        return np.nan
+    sr = sharpe / np.sqrt(1 if periods is None else periods)
+    sr_std = 1 / np.sqrt(n_observations - 1)
+    bar = expected_max_sharpe(n_trials, sr_std)
+    denom = 1 - skew * sr + (kurt - 1) / 4 * sr ** 2
+    if not np.isfinite(denom) or denom <= 0:
+        return np.nan
+    z = (sr - bar) * np.sqrt(n_observations - 1) / np.sqrt(denom)
+    return float(scipy_stats.norm.cdf(z))
+
+
 def sortino_ratio(returns, rf=0, periods=365, annualize=True, smart=False):
     """
     Calculates the sortino ratio of access returns
@@ -401,6 +447,17 @@ def trades(trades_list: List[ClosedTrade], daily_balance: list, final: bool = Tr
     max_underwater_period = np.nan if len(daily_balance) < 2 else calculate_max_underwater_period(daily_balance)
     annual_return = np.nan if len(daily_return) < 2 else cagr(daily_return, periods=365).iloc[0] * 100
     sharpe = np.nan if len(daily_return) < 2 else sharpe_ratio(daily_return, periods=365).iloc[0]
+    # Return-distribution moments for deflated-Sharpe computation downstream
+    # (population moments; kurtosis is non-excess, normal = 3)
+    if len(daily_return) < 3 or float(np.std(daily_return)) == 0:
+        returns_skewness = np.nan
+        returns_kurtosis = np.nan
+    else:
+        _r = np.asarray(daily_return, dtype=float)
+        _mu = _r.mean()
+        _sd = _r.std()
+        returns_skewness = float(((_r - _mu) ** 3).mean() / _sd ** 3)
+        returns_kurtosis = float(((_r - _mu) ** 4).mean() / _sd ** 4)
     calmar = np.nan if len(daily_return) < 2 else calmar_ratio(daily_return).iloc[0]
     sortino = np.nan if len(daily_return) < 2 else sortino_ratio(daily_return, periods=365).iloc[0]
     omega = np.nan if len(daily_return) < 2 else omega_ratio(daily_return, periods=365).iloc[0]
@@ -437,6 +494,9 @@ def trades(trades_list: List[ClosedTrade], daily_balance: list, final: bool = Tr
         'max_underwater_period': safe_convert(max_underwater_period),
         'annual_return': safe_convert(annual_return),
         'sharpe_ratio': safe_convert(sharpe),
+        'sharpe_observations': safe_convert(len(daily_return), int),
+        'returns_skewness': safe_convert(returns_skewness),
+        'returns_kurtosis': safe_convert(returns_kurtosis),
         'calmar_ratio': safe_convert(calmar),
         'sortino_ratio': safe_convert(sortino),
         'omega_ratio': safe_convert(omega),

--- a/jesse/services/metrics.py
+++ b/jesse/services/metrics.py
@@ -101,6 +101,33 @@ def expected_max_sharpe(n_trials: int, sr_std: float) -> float:
     return float(sr_std * ((1 - euler) * z1 + euler * z2))
 
 
+def return_moments(returns) -> tuple:
+    """
+    Population skewness and non-excess kurtosis of a return series, or (nan, nan)
+    when the series carries no dispersion to take moments of.
+
+    A constant series does not reach an exact `std == 0`: its standard deviation is
+    floating-point residue rather than a true zero, so the moments come out as huge
+    finite numbers and the Sharpe divides out to ~1e16. The floor therefore scales
+    with the number of terms summed -- the residue was measured at most 1.96 eps x
+    scale over constant series spanning values 1e-7..1e3 and lengths 3..10000, while
+    a real series with sigma=1e-12 sits more than ten orders of magnitude above
+    n eps x scale.
+    """
+    r = np.asarray(returns, dtype=float)
+    n = len(r)
+    if n < 3:
+        return np.nan, np.nan
+    sd = float(np.std(r))
+    if not sd > n * np.finfo(float).eps * float(np.abs(r).max()):
+        return np.nan, np.nan
+    mu = r.mean()
+    return (
+        float(((r - mu) ** 3).mean() / sd ** 3),
+        float(((r - mu) ** 4).mean() / sd ** 4),
+    )
+
+
 def deflated_sharpe_ratio(
         sharpe: float, n_observations: int, n_trials: int,
         skew: float = 0.0, kurt: float = 3.0, periods=365
@@ -118,6 +145,13 @@ def deflated_sharpe_ratio(
     from scipy import stats as scipy_stats
 
     if n_observations < 3 or not np.isfinite(sharpe):
+        return np.nan
+    # Missing moments mean the return series had no dispersion: its standard deviation
+    # is floating-point residue rather than a true zero, so the Sharpe divides out to
+    # ~1e16 -- finite, and past the check above. Deflating that returned 1.0, i.e.
+    # certainty of a real edge, for the one input that carries no information about
+    # one. Substituting normal moments here would hide exactly that case.
+    if not np.isfinite(skew) or not np.isfinite(kurt):
         return np.nan
     sr = sharpe / np.sqrt(1 if periods is None else periods)
     sr_std = 1 / np.sqrt(n_observations - 1)
@@ -449,15 +483,7 @@ def trades(trades_list: List[ClosedTrade], daily_balance: list, final: bool = Tr
     sharpe = np.nan if len(daily_return) < 2 else sharpe_ratio(daily_return, periods=365).iloc[0]
     # Return-distribution moments for deflated-Sharpe computation downstream
     # (population moments; kurtosis is non-excess, normal = 3)
-    if len(daily_return) < 3 or float(np.std(daily_return)) == 0:
-        returns_skewness = np.nan
-        returns_kurtosis = np.nan
-    else:
-        _r = np.asarray(daily_return, dtype=float)
-        _mu = _r.mean()
-        _sd = _r.std()
-        returns_skewness = float(((_r - _mu) ** 3).mean() / _sd ** 3)
-        returns_kurtosis = float(((_r - _mu) ** 4).mean() / _sd ** 4)
+    returns_skewness, returns_kurtosis = return_moments(daily_return)
     calmar = np.nan if len(daily_return) < 2 else calmar_ratio(daily_return).iloc[0]
     sortino = np.nan if len(daily_return) < 2 else sortino_ratio(daily_return, periods=365).iloc[0]
     omega = np.nan if len(daily_return) < 2 else omega_ratio(daily_return, periods=365).iloc[0]

--- a/tests/test_deflated_sharpe.py
+++ b/tests/test_deflated_sharpe.py
@@ -1,0 +1,36 @@
+import numpy as np
+
+from jesse.services.metrics import deflated_sharpe_ratio, expected_max_sharpe
+
+# Reference values computed with the numguard reference implementation of
+# Bailey & Lopez de Prado (2014): per-period Sharpe = annualized / sqrt(365),
+# null SR std = 1/sqrt(n_observations - 1), exact E[max] formula.
+TOL = 1e-9
+
+
+def test_expected_max_sharpe_matches_reference():
+    assert abs(expected_max_sharpe(200, 1 / np.sqrt(364)) - 0.14495283882665905) < TOL
+    assert expected_max_sharpe(1, 0.1) == 0.0
+
+
+def test_deflated_sharpe_matches_reference():
+    assert abs(deflated_sharpe_ratio(2.0, 365, 200) - 0.221787790810632) < 1e-7
+    assert abs(
+        deflated_sharpe_ratio(1.2, 180, 500, skew=-0.5, kurt=5.0)
+        - 0.014849505815470308
+    ) < 1e-7
+
+
+def test_single_trial_reduces_to_probabilistic_sharpe():
+    # with one trial there is no deflation: the bar is zero
+    assert abs(deflated_sharpe_ratio(2.0, 365, 1) - 0.9768039819822307) < 1e-7
+
+
+def test_deflation_is_monotonic_in_trial_count():
+    values = [deflated_sharpe_ratio(2.0, 365, n) for n in (1, 10, 100, 1000)]
+    assert all(values[i] > values[i + 1] for i in range(len(values) - 1))
+
+
+def test_insufficient_observations_returns_nan():
+    assert np.isnan(deflated_sharpe_ratio(2.0, 2, 10))
+    assert np.isnan(deflated_sharpe_ratio(np.nan, 365, 10))

--- a/tests/test_deflated_sharpe.py
+++ b/tests/test_deflated_sharpe.py
@@ -1,6 +1,10 @@
 import numpy as np
 
-from jesse.services.metrics import deflated_sharpe_ratio, expected_max_sharpe
+from jesse.services.metrics import (
+    deflated_sharpe_ratio,
+    expected_max_sharpe,
+    return_moments,
+)
 
 # Reference values computed with the numguard reference implementation of
 # Bailey & Lopez de Prado (2014): per-period Sharpe = annualized / sqrt(365),
@@ -34,3 +38,35 @@ def test_deflation_is_monotonic_in_trial_count():
 def test_insufficient_observations_returns_nan():
     assert np.isnan(deflated_sharpe_ratio(2.0, 2, 10))
     assert np.isnan(deflated_sharpe_ratio(np.nan, 365, 10))
+
+
+def test_missing_moments_return_nan():
+    # The moments are unavailable exactly when the return series had no dispersion.
+    # Its standard deviation is floating-point residue rather than a true zero, so the
+    # Sharpe divides out to ~1e16 -- finite, and past the isfinite guard. Deflating
+    # that answered 1.0: certainty of an edge, from the one input that cannot show one.
+    assert np.isnan(deflated_sharpe_ratio(8.8e16, 250, 4, skew=np.nan, kurt=np.nan))
+    assert np.isnan(deflated_sharpe_ratio(2.0, 250, 4, skew=np.nan, kurt=3.0))
+    assert np.isnan(deflated_sharpe_ratio(2.0, 250, 4, skew=0.0, kurt=np.nan))
+
+    # Real moments are unaffected.
+    assert 0 <= deflated_sharpe_ratio(2.0, 250, 4, skew=-0.5, kurt=5.0) <= 1
+
+
+def test_return_moments_reject_a_series_with_no_dispersion():
+    # A constant series does not reach an exact `std == 0`: its standard deviation is
+    # floating-point residue rather than a true zero, so the moments came out as huge
+    # finite numbers and the Sharpe divided out to ~1e16 -- which deflated to 1.0,
+    # certainty of an edge from the one input that cannot show one. Checked across
+    # values and lengths, since the residue depends on both.
+    for value in (1e-7, 1e-4, 0.001, 0.01, 1.0, 100.0):
+        for n in (3, 10, 250, 5000):
+            skew, kurt = return_moments(np.full(n, value))
+            assert np.isnan(skew) and np.isnan(kurt), f"leaked at value={value}, n={n}"
+
+    assert all(np.isnan(x) for x in return_moments(np.zeros(250)))
+    assert all(np.isnan(x) for x in return_moments(np.array([0.01, 0.02])))
+
+    # A real but very quiet series still has moments.
+    skew, kurt = return_moments(np.random.default_rng(1).normal(0, 1e-8, 250))
+    assert np.isfinite(skew) and np.isfinite(kurt)


### PR DESCRIPTION
## Why

"By default, Jesse optimizes for the Sharpe ratio" — the study selects the best of `n_trials` Optuna trials. Under pure noise, the best of a large study still shows a high Sharpe: with 200 trials over a year of daily data, the *expected* maximum Sharpe of zero-skill strategies is ≈2.77 annualized. A user reading the winning trial's raw Sharpe can't tell skill from selection.

## What

Each recorded trial's metrics now also carry `deflated_sharpe_ratio` (Bailey & López de Prado, 2014): the probability that the true Sharpe exceeds the expected maximum of `n_trials` zero-skill trials, adjusting for sample length and return skewness/kurtosis. The trial count is the study's own `n_trials` — the one number an optimizer knows precisely.

- `metrics.py`: `expected_max_sharpe()` + `deflated_sharpe_ratio()` (scipy only, already a dependency). The annualized Sharpe is **de-annualized inside the function** — mixing annualized SR with per-period observation counts inflates the statistic by ~√365, a bug I've found live in another trading tool this week. Three new metrics fields (`sharpe_observations`, `returns_skewness`, `returns_kurtosis`) carry the inputs across Ray workers; additive only, no existing keys changed.
- `Optimize.py`: `_attach_deflated_sharpe()` adds the value to training and testing metrics of every recorded trial; no-op when inputs are missing (e.g. too few trades).
- `tests/test_deflated_sharpe.py`: parity against the [numguard](https://github.com/ipezygj/numguard) reference implementation at 1e-7, single-trial-reduces-to-PSR, monotonicity in trial count, NaN guards.

Same math was merged into ffn last week (pmorissette/ffn#311).

## Testing note

The new test functions pass against the extracted implementation (verified locally at the listed tolerances). My local environment is Python 3.14, where test collection fails on the `aioredis` import chain (`duplicate base class TimeoutError`, a known aioredis-2.x incompatibility with 3.11+) before reaching any test — unrelated to this change; CI on a supported Python validates the suite.

Happy to adjust naming or move the display elsewhere (e.g. only testing metrics) if you prefer.