### PR TITLE
Add probabilistic Sharpe ratio metric

### DIFF
--- a/jesse/services/metrics.py
+++ b/jesse/services/metrics.py
@@ -83,6 +83,40 @@ def sharpe_ratio(returns, rf=0.0, periods=365, annualize=True, smart=False):
     return pd.Series([res])
 
 
+def probabilistic_sharpe_ratio(returns, benchmark_sr=0.0):
+    """
+    Calculates the Probabilistic Sharpe Ratio (Bailey & Lopez de Prado, 2012):
+    the probability that the true Sharpe ratio exceeds a benchmark, given the
+    observed Sharpe, the sample length, and the skew and kurtosis of the returns.
+
+    A high (annualized) Sharpe from few observations, or from returns with heavy
+    left tails, carries more uncertainty than the headline number suggests; the
+    PSR turns that into a single probability in [0, 1]. It operates on the same
+    (daily) return series as sharpe_ratio(). The Sharpe is used in its raw,
+    non-annualized per-period form here, so the benchmark is in the same units
+    (default 0, i.e. the probability that the true Sharpe is positive).
+    """
+    returns = _prepare_returns(returns).dropna()
+    n = len(returns)
+    if n < 2:
+        return pd.Series([np.nan])
+
+    std = returns.std(ddof=1)
+    if std == 0:
+        return pd.Series([np.nan])
+    sr = returns.mean() / std
+    skew = returns.skew()
+    # pandas kurtosis() returns EXCESS kurtosis; the closed form needs the raw value
+    kurtosis = returns.kurtosis() + 3
+    denominator = np.sqrt(1 - skew * sr + ((kurtosis - 1) / 4) * sr ** 2)
+    if denominator == 0 or np.isnan(denominator):
+        return pd.Series([np.nan])
+
+    from scipy.stats import norm
+    z = (sr - benchmark_sr) * np.sqrt(n - 1) / denominator
+    return pd.Series([norm.cdf(z)])
+
+
 def sortino_ratio(returns, rf=0, periods=365, annualize=True, smart=False):
     """
     Calculates the sortino ratio of access returns
@@ -401,6 +435,7 @@ def trades(trades_list: List[ClosedTrade], daily_balance: list, final: bool = Tr
     max_underwater_period = np.nan if len(daily_balance) < 2 else calculate_max_underwater_period(daily_balance)
     annual_return = np.nan if len(daily_return) < 2 else cagr(daily_return, periods=365).iloc[0] * 100
     sharpe = np.nan if len(daily_return) < 2 else sharpe_ratio(daily_return, periods=365).iloc[0]
+    probabilistic_sharpe = np.nan if len(daily_return) < 2 else probabilistic_sharpe_ratio(daily_return).iloc[0]
     calmar = np.nan if len(daily_return) < 2 else calmar_ratio(daily_return).iloc[0]
     sortino = np.nan if len(daily_return) < 2 else sortino_ratio(daily_return, periods=365).iloc[0]
     omega = np.nan if len(daily_return) < 2 else omega_ratio(daily_return, periods=365).iloc[0]
@@ -437,6 +472,7 @@ def trades(trades_list: List[ClosedTrade], daily_balance: list, final: bool = Tr
         'max_underwater_period': safe_convert(max_underwater_period),
         'annual_return': safe_convert(annual_return),
         'sharpe_ratio': safe_convert(sharpe),
+        'probabilistic_sharpe_ratio': safe_convert(probabilistic_sharpe),
         'calmar_ratio': safe_convert(calmar),
         'sortino_ratio': safe_convert(sortino),
         'omega_ratio': safe_convert(omega),

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,6 +2,7 @@ from jesse.store import store
 from jesse.testing_utils import single_route_backtest
 from jesse.services import metrics
 import numpy as np
+import pandas as pd
 
 
 def test_open_pl_and_total_open_trades():
@@ -105,3 +106,23 @@ def test_daily_balance_stores_portfolio_value():
         is_futures_trading=False,
         candles_count=10 * 1024
     )
+
+
+def test_probabilistic_sharpe_ratio():
+    # Undefined for fewer than two observations, or a constant (zero-variance) series
+    assert np.isnan(metrics.probabilistic_sharpe_ratio(pd.Series([0.01])).iloc[0])
+    assert np.isnan(metrics.probabilistic_sharpe_ratio(pd.Series([0.01, 0.01, 0.01])).iloc[0])
+
+    # A deterministic, mostly-positive daily return series -> a high but sub-1 probability
+    returns = pd.Series([0.01, -0.005, 0.02, 0.0, 0.015, -0.01, 0.008,
+                         0.012, 0.004, -0.002, 0.011, 0.006])
+    psr = metrics.probabilistic_sharpe_ratio(returns).iloc[0]
+    assert 0.0 < psr < 1.0
+    assert round(psr, 6) == 0.970319
+
+    # A symmetric zero-mean series -> probability the true Sharpe is positive is exactly 0.5
+    symmetric = pd.Series([0.01, -0.01] * 20)
+    assert abs(metrics.probabilistic_sharpe_ratio(symmetric).iloc[0] - 0.5) < 1e-9
+
+    # Raising the benchmark Sharpe can only lower the probability of exceeding it
+    assert metrics.probabilistic_sharpe_ratio(returns, benchmark_sr=0.5).iloc[0] < psr


### PR DESCRIPTION
## What
Adds a `probabilistic_sharpe_ratio` metric (Bailey & López de Prado, 2012) alongside the existing `sharpe_ratio`, and surfaces it in the dict returned by `metrics.trades()` as `probabilistic_sharpe_ratio`.

## Why
A Sharpe ratio is a point estimate. The same headline Sharpe means something very different from 3 months of data than from 3 years, and returns with heavy left tails carry more downside uncertainty than the number shows. The PSR folds sample length, skew and kurtosis into a single probability in `[0, 1]` — the probability the *true* Sharpe exceeds a benchmark (default `0`). It's the standard first-line check against an over-flattering Sharpe and a natural companion to the ratio already reported.

Since Jesse's optimizer maximizes Sharpe by default over many trials, the *deflated* variant (PSR against the expected-max Sharpe of `n_trials`) is a natural follow-up; I kept this PR to the plain PSR to stay minimal and additive.

## How
- New `probabilistic_sharpe_ratio(returns, benchmark_sr=0.0)` in `jesse/services/metrics.py`, immediately after `sharpe_ratio`. It reuses `_prepare_returns`, the same daily return series, the `pd.Series([...])` return convention, and the `len < 2 → nan` guard. `scipy` (already a dependency) supplies the normal CDF; `pandas` excess kurtosis is converted to raw.
- One new key, `probabilistic_sharpe_ratio`, added to the `trades()` metrics dict right after `sharpe_ratio`. Purely additive — no existing keys change.

## Testing
Added `test_probabilistic_sharpe_ratio` in `tests/test_metrics.py`, exercising the function directly on synthetic return series (sidestepping the multi-day-fixture limitation the file notes): a deterministic series with a known value (`0.970319`), a symmetric zero-mean series → exactly `0.5`, benchmark monotonicity, and the `< 2 obs` / zero-variance → `nan` guards.
