### PR TITLE
Align trades Monte Carlo Calmar ratio with CAGR

### DIFF
--- a/jesse/research/monte_carlo/monte_carlo_trades.py
+++ b/jesse/research/monte_carlo/monte_carlo_trades.py
@@ -314,7 +314,14 @@ def _calculate_metrics_from_equity_curve(equity_curve: list, starting_balance: f
     total_return = ((final_value - starting_balance) / starting_balance) * 100
     max_drawdown = _calculate_max_drawdown(values)
     volatility, sharpe_ratio = _calculate_volatility_metrics(values)
-    calmar_ratio = total_return / abs(max_drawdown) if max_drawdown < 0 else 0
+    duration_seconds = data[-1]['time'] - data[0]['time']
+    years = duration_seconds / (ANNUALIZATION_FACTOR * 24 * 60 * 60)
+    annualized_return = 0.0
+    if years > 0:
+        growth_ratio = np.clip(final_value / starting_balance, 1e-10, 1e10)
+        with np.errstate(over='ignore', under='ignore'):
+            annualized_return = (growth_ratio ** (1 / years) - 1) * 100
+    calmar_ratio = annualized_return / abs(max_drawdown) if max_drawdown < 0 else 0
     return {
         'total_return': total_return,
         'final_value': final_value,

--- a/tests/test_monte_carlo_calmar.py
+++ b/tests/test_monte_carlo_calmar.py
@@ -1,0 +1,58 @@
+from datetime import timedelta
+
+import pytest
+
+from jesse.research.monte_carlo.monte_carlo_trades import _calculate_metrics_from_equity_curve
+
+
+SECONDS_PER_YEAR = timedelta(days=365).total_seconds()
+
+
+def _equity_curve(points):
+    return [{
+        'name': 'Portfolio',
+        'data': [
+            {'time': timestamp, 'value': value}
+            for timestamp, value in points
+        ]
+    }]
+
+
+def test_calmar_ratio_uses_annualized_return():
+    result = _calculate_metrics_from_equity_curve(
+        _equity_curve([
+            (0, 100),
+            (SECONDS_PER_YEAR, 90),
+            (2 * SECONDS_PER_YEAR, 121),
+        ]),
+        starting_balance=100,
+    )
+
+    assert result['total_return'] == pytest.approx(21)
+    assert result['max_drawdown'] == pytest.approx(-10)
+    assert result['calmar_ratio'] == pytest.approx(1)
+
+
+def test_calmar_ratio_is_zero_without_positive_time_span():
+    result = _calculate_metrics_from_equity_curve(
+        _equity_curve([
+            (0, 100),
+            (0, 90),
+            (0, 121),
+        ]),
+        starting_balance=100,
+    )
+
+    assert result['calmar_ratio'] == 0
+
+
+def test_calmar_ratio_is_zero_without_drawdown():
+    result = _calculate_metrics_from_equity_curve(
+        _equity_curve([
+            (0, 100),
+            (SECONDS_PER_YEAR, 121),
+        ]),
+        starting_balance=100,
+    )
+
+    assert result['calmar_ratio'] == 0


### PR DESCRIPTION
Fixes #606

## Summary

- Annualize each Monte Carlo equity curve's return over its timestamp span before calculating the Calmar ratio.
- Preserve a zero Calmar ratio for non-positive time spans or curves without drawdown.
- Add focused regression coverage for the corrected formula and boundary cases.

## Root cause and impact

The trades-based Monte Carlo scenarios used cumulative total return divided by maximum drawdown, while the `original` column used CAGR divided by maximum drawdown. On multi-year backtests, this put adjacent values on different scales, inflated scenario Calmar ratios, and made the resulting p-value misleading.

For example, a curve growing from 100 to 121 over two years with a 10% maximum drawdown now produces a 10% annualized return and a Calmar ratio of 1, rather than using the 21% cumulative return and reporting 2.1.

## Coordination with #608

This change is intentionally separate from #608, which addresses #607 by changing how shuffled trade equity paths are reconstructed. This PR only calculates metrics from an already reconstructed curve and does not change trade ordering, compounding, drawdown, volatility, or Sharpe calculations.

Both changes touch `monte_carlo_trades.py`, so a small rebase may be required if #608 merges first, but the fixes are logically independent.

## Tests

- Focused regression tests: 3 passed using an isolated test harness.
- Independent formula validation covered two-year and one-year gains, a multi-year loss, zero duration, and no drawdown.
- Python syntax and Git diff checks passed.

The full Jesse suite was not run locally because the complete Jesse/Ray dependency environment is unavailable. Repository CI will run the supported platform and Python matrix.
