### PR TITLE
Fix silent live session stalls

### DIFF
--- a/jesse/services/failure.py
+++ b/jesse/services/failure.py
@@ -2,10 +2,18 @@ import jesse.helpers as jh
 from jesse.services import logger as jesse_logger
 import threading
 import traceback
+import os
 from jesse.services.redis import sync_publish
 from jesse.repositories import live_session_repository
 from jesse.store import store
 from jesse.enums import live_session_statuses
+
+
+def _terminal_debug(message: str) -> None:
+    try:
+        jh.terminal_debug(message)
+    except Exception:
+        pass
 
 
 def register_custom_exception_handler() -> None:
@@ -14,45 +22,65 @@ def register_custom_exception_handler() -> None:
         if args.exc_type == SystemExit:
             return
 
+        formatted_traceback = ''.join(
+            traceback.format_exception(args.exc_type, args.exc_value, args.exc_traceback)
+        )
+
         if args.exc_type.__name__ == 'Termination':
             sync_publish('termination', {})
             jh.terminate_app()
         else:
             # send notifications if it's a live session
             if jh.is_live():
-                jesse_logger.error(
-                    f'{args.exc_type.__name__}: {args.exc_value}'
-                )
-                jesse_logger.info(
-                    str(traceback.format_exc())
-                )
-                
+                try:
+                    jesse_logger.error(
+                        f'{args.exc_type.__name__}: {args.exc_value}'
+                    )
+                    jesse_logger.info(formatted_traceback)
+                except Exception as e:
+                    _terminal_debug(
+                        f'Error logging uncaught thread exception: {type(e).__name__}: {e}\n{formatted_traceback}'
+                    )
+
                 # Store exception in live session
                 try:
                     live_session_repository.store_live_session_exception(
                         store.app.session_id,
                         f"{args.exc_type.__name__}: {str(args.exc_value)}",
-                        str(traceback.format_exc())
+                        formatted_traceback
                     )
                     live_session_repository.update_live_session_status(store.app.session_id, live_session_statuses.STOPPED)
                     live_session_repository.update_live_session_finished(store.app.session_id)
                 except Exception as e:
-                    jh.debug(f'Error storing live session exception: {e}')
+                    _terminal_debug(f'Error storing live session exception: {type(e).__name__}: {e}')
 
-            sync_publish('exception', {
-                'error': f"{args.exc_type.__name__}: {str(args.exc_value)}",
-                'traceback': str(traceback.format_exc())
-            })
-            terminate_session()
+            try:
+                sync_publish('exception', {
+                    'error': f"{args.exc_type.__name__}: {str(args.exc_value)}",
+                    'traceback': formatted_traceback
+                })
+            finally:
+                terminate_session()
 
     threading.excepthook = handle_thread_exception
 
 
 def terminate_session():
-    sync_publish('unexpectedTermination', {
-        'message': "Session terminated as the result of an uncaught exception",
-    })
+    try:
+        sync_publish('unexpectedTermination', {
+            'message': "Session terminated as the result of an uncaught exception",
+        })
+    except Exception as e:
+        _terminal_debug(f'Error publishing unexpected session termination: {type(e).__name__}: {e}')
 
-    jesse_logger.error('Session terminated as the result of an uncaught exception')
+    try:
+        jesse_logger.error('Session terminated as the result of an uncaught exception')
+    except Exception as e:
+        _terminal_debug(f'Error logging unexpected session termination: {type(e).__name__}: {e}')
 
-    jh.terminate_app()
+    try:
+        jh.terminate_app()
+    except BaseException as e:
+        _terminal_debug(f'Error closing resources during session termination: {type(e).__name__}: {e}')
+    finally:
+        os._exit(1)

--- a/jesse/services/multiprocessing.py
+++ b/jesse/services/multiprocessing.py
@@ -14,6 +14,13 @@ import signal
 mp.set_start_method('spawn', force=True)
 
 
+def _terminal_debug(message: str) -> None:
+    try:
+        jh.terminal_debug(message)
+    except Exception:
+        pass
+
+
 class Process(mp.Process):
     def __init__(self, *args, **kwargs):
         mp.Process.__init__(self, *args, **kwargs)
@@ -130,6 +137,17 @@ class ProcessManager:
                                 prefixed_client_id = self._pid_to_client_id_map.get(prefixed_pid)
 
                                 w.join(timeout=1)
+                                exit_code = w.exitcode
+                                worker_pid = w.pid
+                                client_id = (
+                                    jh.string_after_character(prefixed_client_id, '|')
+                                    if prefixed_client_id
+                                    else 'unknown'
+                                )
+                                _terminal_debug(
+                                    f'Worker {client_id} (PID {worker_pid}) exited with code {exit_code}'
+                                )
+
                                 w.close()
                                 self._workers.remove(w)
                                 self._pid_to_client_id_map.pop(prefixed_pid, None)
@@ -139,13 +157,17 @@ class ProcessManager:
                                     and self.client_id_to_pid_to_map.get(prefixed_client_id) == prefixed_pid
                                 ):
                                     self.client_id_to_pid_to_map.pop(prefixed_client_id, None)
-                                    client_id = jh.string_after_character(prefixed_client_id, '|')
-                                    sync_redis.srem(self._active_workers_key, client_id)
-                                    jh.debug(f"Removed finished worker {client_id} from active workers")
+                                    try:
+                                        sync_redis.srem(self._active_workers_key, client_id)
+                                    except Exception as e:
+                                        _terminal_debug(
+                                            f'Error removing finished worker {client_id} from Redis: {type(e).__name__}: {e}'
+                                        )
+                                    _terminal_debug(f"Cleaned up finished worker {client_id}")
                             except Exception as e:
-                                jh.debug(f"Error during worker cleanup: {str(e)}")
+                                _terminal_debug(f"Error during worker cleanup: {type(e).__name__}: {e}")
             except Exception as e:
-                jh.debug(f"Error in cleanup thread: {str(e)}")
+                _terminal_debug(f"Error in cleanup thread: {type(e).__name__}: {e}")
             time.sleep(5)
 
     @property

--- a/jesse/services/redis.py
+++ b/jesse/services/redis.py
@@ -1,7 +1,12 @@
 import aioredis
 import redis as sync_redis_lib
+from redis.exceptions import (
+    ConnectionError as RedisConnectionError,
+    TimeoutError as RedisTimeoutError,
+)
 import simplejson as json
 import asyncio
+import time
 import jesse.helpers as jh
 from jesse.libs.custom_json import NpEncoder
 import os
@@ -19,12 +24,16 @@ async def init_redis():
 
 async_redis = None
 sync_redis = None
+_last_active_check_error_at = 0
 if jh.is_jesse_project():
     if not jh.is_notebook():
         async_redis = asyncio.run(init_redis())
         sync_redis = sync_redis_lib.Redis(
             host=ENV_VALUES['REDIS_HOST'], port=ENV_VALUES['REDIS_PORT'], db=int(ENV_VALUES.get('REDIS_DB') or 0),
-            password=ENV_VALUES['REDIS_PASSWORD'] if ENV_VALUES['REDIS_PASSWORD'] else None
+            password=ENV_VALUES['REDIS_PASSWORD'] if ENV_VALUES['REDIS_PASSWORD'] else None,
+            socket_connect_timeout=1,
+            socket_timeout=1,
+            health_check_interval=30,
         )
 
 
@@ -105,7 +114,23 @@ def get_live_charts_snapshot(session_id: str) -> dict:
 
 
 def is_process_active(client_id: str) -> bool:
+    global _last_active_check_error_at
+
     if jh.is_unit_testing():
         return False
 
-    return sync_redis.sismember(f"{ENV_VALUES['APP_PORT']}|active-processes", client_id)
+    try:
+        is_active = sync_redis.sismember(f"{ENV_VALUES['APP_PORT']}|active-processes", client_id)
+        _last_active_check_error_at = 0
+        return is_active
+    except (RedisConnectionError, RedisTimeoutError, OSError) as e:
+        now = time.monotonic()
+        if _last_active_check_error_at == 0 or now - _last_active_check_error_at >= 30:
+            try:
+                jh.terminal_debug(
+                    f'Redis active-process check failed for {client_id}; keeping the worker active: {type(e).__name__}: {e}'
+                )
+            except Exception:
+                pass
+            _last_active_check_error_at = now
+        return True


### PR DESCRIPTION
## Summary

- bound synchronous Redis connection and read operations so a worker cannot wait indefinitely
- keep a running worker active during transient Redis connectivity failures, with rate-limited diagnostics
- preserve real background-thread tracebacks and guarantee failed sessions terminate even if secondary reporting fails
- report child-process exit codes before cleanup so abnormal exits remain diagnosable

## Verification

- `python -m compileall -q jesse/services/redis.py jesse/services/failure.py jesse/services/multiprocessing.py`
- `git diff --check`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_live_strategy_charts.py -q` — 8 passed
- exercised Redis timeout, fail-open activity checks, background-thread traceback capture, cascading reporting failures, forced termination, and Redis-failing worker cleanup with a standalone failure-path harness

## Notes

The local pytest environment has an incompatible auto-loaded `anyio` plugin (`_pytest.scope` is unavailable), so the targeted suite was run with third-party plugin autoload disabled.
