### PR TITLE
fix: aggregate existing candle metadata query

### DIFF
--- a/jesse/repositories/candle_repository.py
+++ b/jesse/repositories/candle_repository.py
@@ -3,6 +3,7 @@ import jesse.helpers as jh
 from typing import List
 import numpy as np
 import arrow
+from peewee import fn
 
 
 def delete_candles_from_db(exchange: str, symbol: str) -> None:
@@ -28,40 +29,30 @@ def get_existing_candles() -> List[dict]:
     Returns a list of all existing candles grouped by exchange and symbol
     """
     results = []
-    
-    # Get unique exchange-symbol combinations
+
+    # Aggregate all pairs in one query. The previous distinct-pairs plus
+    # first/last lookup loop issued two extra queries for every pair, which
+    # made this metadata endpoint time out on larger candle databases.
     pairs = Candle.select(
-        Candle.exchange, 
-        Candle.symbol
-    ).distinct().tuples()
+        Candle.exchange,
+        Candle.symbol,
+        fn.MIN(Candle.timestamp).alias('first_timestamp'),
+        fn.MAX(Candle.timestamp).alias('last_timestamp'),
+    ).group_by(
+        Candle.exchange,
+        Candle.symbol,
+    ).order_by(
+        Candle.exchange,
+        Candle.symbol,
+    ).tuples()
 
-    for exchange, symbol in pairs:
-        # Get first and last candle for this pair
-        first = Candle.select(
-            Candle.timestamp
-        ).where(
-            Candle.exchange == exchange,
-            Candle.symbol == symbol
-        ).order_by(
-            Candle.timestamp.asc()
-        ).first()
-
-        last = Candle.select(
-            Candle.timestamp
-        ).where(
-            Candle.exchange == exchange,
-            Candle.symbol == symbol
-        ).order_by(
-            Candle.timestamp.desc()
-        ).first()
-
-        if first and last:
-            results.append({
-                'exchange': exchange,
-                'symbol': symbol,
-                'start_date': arrow.get(first.timestamp / 1000).format('YYYY-MM-DD'),
-                'end_date': arrow.get(last.timestamp / 1000).format('YYYY-MM-DD')
-            })
+    for exchange, symbol, first_timestamp, last_timestamp in pairs:
+        results.append({
+            'exchange': exchange,
+            'symbol': symbol,
+            'start_date': arrow.get(first_timestamp / 1000).format('YYYY-MM-DD'),
+            'end_date': arrow.get(last_timestamp / 1000).format('YYYY-MM-DD')
+        })
 
     return results
 

--- a/tests/test_candle_repository.py
+++ b/tests/test_candle_repository.py
@@ -1,0 +1,75 @@
+import peewee
+
+from jesse.models.Candle import Candle
+from jesse.repositories import candle_repository
+
+
+def test_get_existing_candles_uses_one_query_for_all_pairs():
+    database = peewee.SqliteDatabase(':memory:')
+
+    with database.bind_ctx([Candle]):
+        database.create_tables([Candle])
+        Candle.insert_many([
+            {
+                'id': '00000000-0000-4000-8000-000000000001',
+                'timestamp': 1704067200000,
+                'open': 100,
+                'close': 101,
+                'high': 102,
+                'low': 99,
+                'volume': 10,
+                'exchange': 'Binance Perpetual Futures',
+                'symbol': 'BTC-USDT',
+                'timeframe': '1m',
+            },
+            {
+                'id': '00000000-0000-4000-8000-000000000002',
+                'timestamp': 1709251200000,
+                'open': 110,
+                'close': 111,
+                'high': 112,
+                'low': 109,
+                'volume': 20,
+                'exchange': 'Binance Perpetual Futures',
+                'symbol': 'BTC-USDT',
+                'timeframe': '1h',
+            },
+            {
+                'id': '00000000-0000-4000-8000-000000000003',
+                'timestamp': 1706745600000,
+                'open': 200,
+                'close': 201,
+                'high': 202,
+                'low': 199,
+                'volume': 30,
+                'exchange': 'Binance Spot',
+                'symbol': 'ETH-USDT',
+                'timeframe': '1h',
+            },
+        ]).execute()
+
+        statements = []
+        database.connection().set_trace_callback(statements.append)
+
+        result = candle_repository.get_existing_candles()
+
+    select_statements = [
+        statement for statement in statements
+        if statement.lstrip().upper().startswith('SELECT')
+    ]
+
+    assert len(select_statements) == 1
+    assert result == [
+        {
+            'exchange': 'Binance Perpetual Futures',
+            'symbol': 'BTC-USDT',
+            'start_date': '2024-01-01',
+            'end_date': '2024-03-01',
+        },
+        {
+            'exchange': 'Binance Spot',
+            'symbol': 'ETH-USDT',
+            'start_date': '2024-02-01',
+            'end_date': '2024-02-01',
+        },
+    ]


### PR DESCRIPTION
## Summary

Issue: 
For N pairs `get_existing_candles()` makes 1 + 2N database queries. With a large candle database, the MCP request can exceed ts fixed 10-second timeout. This blocks candle inventory/preflight, not necessarily backtest execution.

- Replace the N+1 candle-inventory query with one grouped aggregate query.
- Preserve the existing exchange/symbol response shape and date semantics.
- Add a regression test that counts generated SQL statements.

## Root cause

`get_existing_candles()` first selected distinct exchange/symbol pairs, then issued separate first/last timestamp queries for every pair. On larger candle databases this caused the MCP request to exceed its 10-second client timeout.

## Validation

- The new regression test failed against pristine upstream `43c8367` with 5 SELECT statements for 2 pairs.
- The regression test passes after the change.
- Adjacent candle/database tests: 37 passed.
- Full non-slow suite: 622 passed, 3 deselected.

Tests ran in the `salehmir/jesse:latest` Docker test environment with pytest plugin autoload disabled.

Fixes #618
