### PR TITLE
Fix double fee haircut in risk_to_qty

### DIFF
--- a/jesse/utils.py
+++ b/jesse/utils.py
@@ -161,9 +161,6 @@ def risk_to_qty(capital: float, risk_per_capital: float, entry_price: float, sto
     risk_per_qty = abs(entry_price - stop_loss_price)
     size = risk_to_size(capital, risk_per_capital, risk_per_qty, entry_price)
 
-    if fee_rate != 0:
-        size = size * (1 - fee_rate * 3)
-
     return size_to_qty(size, entry_price, precision=precision, fee_rate=fee_rate)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -100,7 +100,14 @@ def test_risk_to_qty():
     assert utils.risk_to_qty(10000, 5, 100, 96) == 100
 
     # when fee is included
-    assert utils.risk_to_qty(10000, 1, 100, 80, precision=3, fee_rate=0.001) == 4.97
+    assert utils.risk_to_qty(10000, 1, 100, 80, precision=3, fee_rate=0.001) == 4.985
+
+
+def test_risk_to_qty_single_fee_haircut_issue_614():
+    # fee_rate=0 must stay the uncapped-by-fee path (no double-apply possible)
+    assert utils.risk_to_qty(10000, 10, 100, 90, fee_rate=0) == 100
+    # a single (1 - fee_rate * 3) haircut: 10000 * (1 - 0.005 * 3) / 100 == 98.5
+    assert utils.risk_to_qty(10000, 10, 100, 90, fee_rate=0.005) == 98.5
 
 
 def test_risk_to_size():


### PR DESCRIPTION
Fixes #614

Credit to @flyerswk for reporting this and pinpointing the double application.

`risk_to_qty` reduced `size` by `(1 - fee_rate * 3)` and then called `size_to_qty(..., fee_rate=fee_rate)`, which applies the same haircut again.

On the reporter inputs that produced a double-haircut qty of 97.0225 instead of a single haircut of 98.5:

```python
risk_to_qty(10000, 10, 100, 90, fee_rate=0.005)
```

This drops the pre-adjust in `risk_to_qty` and lets `size_to_qty` apply the fee once. `size_to_qty` itself is unchanged, so other callers keep the same behavior.

`risk_to_qty(10000, 10, 100, 90, fee_rate=0.005)` now returns 98.5.