### PR TITLE
Fix get_existing_candles timeout on large databases

### DIFF
--- a/jesse/repositories/candle_repository.py
+++ b/jesse/repositories/candle_repository.py
@@ -27,41 +27,64 @@ def get_existing_candles() -> List[dict]:
     """
     Returns a list of all existing candles grouped by exchange and symbol
     """
+    # Peewee can't express this, so we use raw SQL. A DISTINCT or GROUP BY over
+    # the candle table reads every row, which takes minutes on large databases.
+    # This recursive CTE emulates an index skip scan (PostgreSQL has no native
+    # one before v18): each step jumps straight to the next
+    # (exchange, symbol, timeframe) group with a single probe of the compound
+    # index, and the first/last timestamps are read with two more index probes
+    # per group. When no next group exists the probes return a NULL row, which
+    # stops the recursion and is filtered out below. The SQL is portable
+    # between PostgreSQL and SQLite (used by the unit tests).
+    query = """
+        WITH RECURSIVE timeframe_groups (exchange, symbol, timeframe) AS (
+            SELECT exchange, symbol, timeframe FROM (
+                SELECT exchange, symbol, timeframe
+                FROM candle
+                ORDER BY exchange, symbol, timeframe
+                LIMIT 1
+            ) AS first_group
+            UNION ALL
+            SELECT
+                (SELECT c.exchange FROM candle c
+                 WHERE (c.exchange, c.symbol, c.timeframe) > (g.exchange, g.symbol, g.timeframe)
+                 ORDER BY c.exchange, c.symbol, c.timeframe LIMIT 1),
+                (SELECT c.symbol FROM candle c
+                 WHERE (c.exchange, c.symbol, c.timeframe) > (g.exchange, g.symbol, g.timeframe)
+                 ORDER BY c.exchange, c.symbol, c.timeframe LIMIT 1),
+                (SELECT c.timeframe FROM candle c
+                 WHERE (c.exchange, c.symbol, c.timeframe) > (g.exchange, g.symbol, g.timeframe)
+                 ORDER BY c.exchange, c.symbol, c.timeframe LIMIT 1)
+            FROM timeframe_groups g
+            WHERE g.exchange IS NOT NULL
+        )
+        SELECT exchange, symbol, MIN(first_timestamp), MAX(last_timestamp)
+        FROM (
+            SELECT
+                g.exchange,
+                g.symbol,
+                (SELECT MIN(c."timestamp") FROM candle c
+                 WHERE c.exchange = g.exchange AND c.symbol = g.symbol AND c.timeframe = g.timeframe) AS first_timestamp,
+                (SELECT MAX(c."timestamp") FROM candle c
+                 WHERE c.exchange = g.exchange AND c.symbol = g.symbol AND c.timeframe = g.timeframe) AS last_timestamp
+            FROM timeframe_groups g
+            WHERE g.exchange IS NOT NULL
+        ) AS group_ranges
+        GROUP BY exchange, symbol
+        ORDER BY exchange, symbol
+    """
+
+    # go through the model's database handle so unit tests can rebind it
+    cursor = Candle._meta.database.execute_sql(query)
+
     results = []
-    
-    # Get unique exchange-symbol combinations
-    pairs = Candle.select(
-        Candle.exchange, 
-        Candle.symbol
-    ).distinct().tuples()
-
-    for exchange, symbol in pairs:
-        # Get first and last candle for this pair
-        first = Candle.select(
-            Candle.timestamp
-        ).where(
-            Candle.exchange == exchange,
-            Candle.symbol == symbol
-        ).order_by(
-            Candle.timestamp.asc()
-        ).first()
-
-        last = Candle.select(
-            Candle.timestamp
-        ).where(
-            Candle.exchange == exchange,
-            Candle.symbol == symbol
-        ).order_by(
-            Candle.timestamp.desc()
-        ).first()
-
-        if first and last:
-            results.append({
-                'exchange': exchange,
-                'symbol': symbol,
-                'start_date': arrow.get(first.timestamp / 1000).format('YYYY-MM-DD'),
-                'end_date': arrow.get(last.timestamp / 1000).format('YYYY-MM-DD')
-            })
+    for exchange, symbol, first_timestamp, last_timestamp in cursor.fetchall():
+        results.append({
+            'exchange': exchange,
+            'symbol': symbol,
+            'start_date': arrow.get(first_timestamp / 1000).format('YYYY-MM-DD'),
+            'end_date': arrow.get(last_timestamp / 1000).format('YYYY-MM-DD')
+        })
 
     return results
 

--- a/tests/test_candle_repository.py
+++ b/tests/test_candle_repository.py
@@ -1,0 +1,65 @@
+import peewee
+
+from jesse.models.Candle import Candle
+from jesse.repositories import candle_repository
+
+
+def _candle_row(candle_id: str, timestamp: int, exchange: str, symbol: str, timeframe: str) -> dict:
+    return {
+        'id': candle_id,
+        'timestamp': timestamp,
+        'open': 100,
+        'close': 101,
+        'high': 102,
+        'low': 99,
+        'volume': 10,
+        'exchange': exchange,
+        'symbol': symbol,
+        'timeframe': timeframe,
+    }
+
+
+def test_get_existing_candles_aggregates_timeframes_in_one_query():
+    database = peewee.SqliteDatabase(':memory:')
+    with database.bind_ctx([Candle]):
+        database.create_tables([Candle])
+        Candle.insert_many([
+            # the start date comes from the 1m timeframe, the end date from the 1h timeframe
+            _candle_row('00000000-0000-4000-8000-000000000001', 1704067200000, 'Binance Perpetual Futures', 'BTC-USDT', '1m'),
+            _candle_row('00000000-0000-4000-8000-000000000002', 1706745600000, 'Binance Perpetual Futures', 'BTC-USDT', '1m'),
+            _candle_row('00000000-0000-4000-8000-000000000003', 1709251200000, 'Binance Perpetual Futures', 'BTC-USDT', '1h'),
+            _candle_row('00000000-0000-4000-8000-000000000004', 1706745600000, 'Binance Spot', 'ETH-USDT', '1h'),
+            _candle_row('00000000-0000-4000-8000-000000000005', 1719792000000, 'Binance Spot', 'ETH-USDT', '1m'),
+        ]).execute()
+
+        statements = []
+        database.connection().set_trace_callback(statements.append)
+
+        result = candle_repository.get_existing_candles()
+
+    # the whole listing must be a single round trip (the query starts with WITH)
+    query_statements = [s for s in statements if s.lstrip().upper().startswith(('SELECT', 'WITH'))]
+    assert len(query_statements) == 1
+
+    assert result == [
+        {
+            'exchange': 'Binance Perpetual Futures',
+            'symbol': 'BTC-USDT',
+            'start_date': '2024-01-01',
+            'end_date': '2024-03-01'
+        },
+        {
+            'exchange': 'Binance Spot',
+            'symbol': 'ETH-USDT',
+            'start_date': '2024-02-01',
+            'end_date': '2024-07-01'
+        },
+    ]
+
+
+def test_get_existing_candles_returns_empty_list_for_empty_database():
+    database = peewee.SqliteDatabase(':memory:')
+    with database.bind_ctx([Candle]):
+        database.create_tables([Candle])
+
+        assert candle_repository.get_existing_candles() == []


### PR DESCRIPTION
## Summary

- Replace the N+1 queries in `get_existing_candles()` with one recursive-CTE query that emulates an index skip scan over the `(exchange, symbol, timeframe, timestamp)` compound index.
- Preserve the exact response shape (`exchange`, `symbol`, `start_date`, `end_date`) and date semantics; results are now deterministically ordered by exchange and symbol.
- Add regression tests (in-memory SQLite): cross-timeframe min/max aggregation, empty database, and a single-SQL-statement assertion.

## Root cause

`get_existing_candles()` selects the distinct exchange/symbol pairs and then issues two ordered queries per pair. The `DISTINCT` alone reads every candle row, and the per-pair queries cannot use the compound index for `ORDER BY timestamp` because `timeframe` sits between `symbol` and `timestamp` in the key. On large databases the endpoint takes minutes, so the MCP client's fixed 10-second timeout always fires (#618).

Collapsing everything into a single `GROUP BY` aggregate (the approach in #616) removes the N+1 pattern but still reads all N rows in one pass. PostgreSQL has no native index skip scan (before v18), but a recursive CTE can emulate one: each recursion step jumps directly to the next `(exchange, symbol, timeframe)` group with a row-value probe of the compound index, then the first/last timestamps are read with two more index probes per group. Cost drops from O(N) to O(groups x log N).

## Benchmarks

Production database: PostgreSQL 14.23, `candle` table with 663,146,368 rows (~176 GB), 536 exchange/symbol pairs.

| implementation | time |
| --- | --- |
| current N+1 loop | 15-20 min |
| single GROUP BY aggregate (#616 approach) | 3 min 11.6 s |
| recursive CTE skip scan (this PR) | 25-40 ms warm cache, ~1.0 s cold cache |

`EXPLAIN ANALYZE` confirms every step is an index-only probe: `Index Cond: (ROW(exchange, symbol, timeframe) > ROW(...))` with `Limit 1`, and the min/max lookups become forward/backward index-only scans.

## Validation

- Result set verified byte-identical (diff of 536 rows) to a `GROUP BY exchange, symbol` full-scan aggregate on the same 663M-row database.
- End-to-end `POST /candles/existing` returns in ~60 ms against that database, and the MCP `get_existing_candles` tool now completes well within its 10-second timeout (previously it always failed).
- The raw SQL is portable between PostgreSQL and SQLite and runs through the model's bound database handle, so the new tests exercise the real production code path against in-memory SQLite (row-value comparisons require SQLite >= 3.15; every Python >= 3.10 build ships a newer one).
- Full non-slow suite passes in the `salehmir/jesse:latest` Docker environment with `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` (572 passed, 3 deselected, plus the 2 new tests).

Fixes #618
